### PR TITLE
fix: memory safety bugs in AxBRowIP.c and add CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+project(rv_sparse VERSION 0.1.0 LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -O3")
+
+add_executable(SpGEMM src/matmul/AxBRowIP.c)

--- a/src/matmul/AxBRowIP.c
+++ b/src/matmul/AxBRowIP.c
@@ -1,152 +1,119 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void RowWiseInnerProduct(const int M, const int K, const int N, float* aD, int* aC, int* aR, float* bD, int* bC, int* bR, float* cD, int* cC, int* cR){
+void RowWiseInnerProduct(const int M, const int __attribute__((unused)) K, const int N,
+                         float* aD, int* aC, int* aR,
+                         float* bD, int* bC, int* bR,
+                         float* cD, int* cC, int* cR) {
     int row_count = 0;
-    for(int row=0; row<M; row++){
+    for (int row = 0; row < M; row++) {
         cR[row] = row_count;
-        float* cD_ = (float *)malloc(K*sizeof(float));
-        for(int col=aR[row]; col<aR[row+1]; col++){
+
+        float* cD_ = (float *)calloc(N, sizeof(float));
+        if (!cD_) {
+            fprintf(stderr, "Out of memory at row %d\n", row);
+            exit(1);
+        }
+
+        for (int col = aR[row]; col < aR[row + 1]; col++) {
             float valA = aD[col];
-            for(int b_col=bR[aC[col]]; b_col<bR[aC[col]+1]; b_col++){
+            for (int b_col = bR[aC[col]]; b_col < bR[aC[col] + 1]; b_col++) {
                 float valB = bD[b_col];
-                // int idx = row*K + bC[b_col];
                 int idx = bC[b_col];
                 cD_[idx] += valA * valB;
             }
         }
-        for (int i=0; i<K; i++){
-            if (cD_[i] != 0){
+
+        for (int i = 0; i < N; i++) {
+            if (cD_[i] != 0.0f) {
                 cC[row_count] = i;
                 cD[row_count] = cD_[i];
                 row_count++;
             }
         }
+
+        free(cD_);
     }
     cR[M] = row_count;
 }
 
-float cNNZ_estimation(int M, int K, int N, int aNNZ, int bNNZ){
-    long long MxK = (long long)M*(long long)K;
-    float density = (float)(aNNZ)/MxK + (float)(bNNZ)/MxK;
-    return density * M * N;
+static long long safe_cNNZ(int M, int N) {
+    return (long long)M * N;
 }
 
-int main(){
-    FILE *file;
-    FILE *file1;
-    FILE *file2;
-    FILE *file3;
+int main() {
+    FILE *file, *file1, *file2, *file3;
 
-    int* gInfo = (int *)malloc(4*sizeof(int));
-    //////////////////////////////////////////
-    int number;
+    int gInfo[4];
     file3 = fopen("MatData/GeneralInfo.txt", "r");
-    if (file3 == NULL) {
-        perror("Error opening file");
-        return -1;
-    }
-    int idx = 0;
-    while (fscanf(file3, "%d", &number) == 1) {
-        gInfo[idx] = number;
-        idx++;
+    if (!file3) { perror("Error opening GeneralInfo.txt"); return -1; }
+    for (int i = 0; i < 4; i++) {
+        if (fscanf(file3, "%d", &gInfo[i]) != 1) {
+            fprintf(stderr, "GeneralInfo.txt has fewer than 4 entries\n");
+            fclose(file3);
+            return -1;
+        }
     }
     fclose(file3);
-    //////////////////////////////////////////
 
     const int M    = gInfo[0];
     const int K    = gInfo[1];
-    const int N    = gInfo[0];
+    const int N    = gInfo[1];
     const int aNNZ = gInfo[2];
     const int bNNZ = gInfo[2];
-    const int rN   = gInfo[3];
 
-    float* aD = (float *)malloc(aNNZ*sizeof(float));
-    int*   aC = (int *)malloc(aNNZ*sizeof(int));
-    int*   aR = (int *)malloc((M+1)*sizeof(int));
+    float* aD = (float *)malloc(aNNZ * sizeof(float));
+    int*   aC = (int   *)malloc(aNNZ * sizeof(int));
+    int*   aR = (int   *)malloc((M + 1) * sizeof(int));
+    float* bD = (float *)malloc(bNNZ * sizeof(float));
+    int*   bC = (int   *)malloc(bNNZ * sizeof(int));
+    int*   bR = (int   *)malloc((K + 1) * sizeof(int));
 
-    float* bD = (float *)malloc(bNNZ*sizeof(float));
-    int*   bC = (int *)malloc(bNNZ*sizeof(int));
-    int*   bR = (int *)malloc((K+1)*sizeof(int));
-
-    //////////////////////////////////////////
-    idx = 0;
-    file = fopen("MatData/CSR_values.txt", "r");
-    if (file == NULL) {
-        perror("Error opening file");
+    if (!aD || !aC || !aR || !bD || !bC || !bR) {
+        fprintf(stderr, "Out of memory allocating input matrices\n");
         return -1;
     }
+
+    int idx = 0;
     float val;
-    while (fscanf(file, "%f", &val) == 1) {
-        aD[idx] = val;
-        bD[idx] = val;
-        idx++;
-    }
+
+    file = fopen("MatData/CSR_values.txt", "r");
+    if (!file) { perror("Error opening CSR_values.txt"); return -1; }
+    while (fscanf(file, "%f", &val) == 1) { aD[idx] = bD[idx] = val; idx++; }
     fclose(file);
 
-    //////////////////////////////////////////
+    int number;
     file1 = fopen("MatData/CSR_colIdx.txt", "r");
-    if (file1 == NULL) {
-        perror("Error opening file");
-        return -1;
-    }
+    if (!file1) { perror("Error opening CSR_colIdx.txt"); return -1; }
     idx = 0;
-    while (fscanf(file1, "%d", &number) == 1) {
-        aC[idx] = number;
-        bC[idx] = number;
-        idx++;
-    }
+    while (fscanf(file1, "%d", &number) == 1) { aC[idx] = bC[idx] = number; idx++; }
     fclose(file1);
-    //////////////////////////////////////////
+
     file2 = fopen("MatData/CSR_rowPtr.txt", "r");
-    if (file2 == NULL) {
-        perror("Error opening file");
+    if (!file2) { perror("Error opening CSR_rowPtr.txt"); return -1; }
+    idx = 0;
+    while (fscanf(file2, "%d", &number) == 1) { aR[idx] = bR[idx] = number; idx++; }
+    fclose(file2);
+
+    long long cNNZ = safe_cNNZ(M, N);
+    printf("Output buffer size = %lld\n", cNNZ);
+
+    float* cD = (float *)malloc(cNNZ * sizeof(float));
+    int*   cC = (int   *)malloc(cNNZ * sizeof(int));
+    int*   cR = (int   *)malloc((M + 1) * sizeof(int));
+
+    if (!cD || !cC || !cR) {
+        fprintf(stderr, "Out of memory allocating output matrix\n");
         return -1;
     }
-    idx = 0;
-    while (fscanf(file2, "%d", &number) == 1) {
-        aR[idx] = number;
-        bR[idx] = number;
-        idx++;
-    }
-    fclose(file2);
-    //////////////////////////////////////////
-
-    int cNNZ = cNNZ_estimation(M,K,N,aNNZ,bNNZ);
-    printf("Estimated cNNZ = %d \n", cNNZ);
-
-    float* cD = (float *)malloc(cNNZ*sizeof(float));
-    int* cC = (int *)malloc(cNNZ*sizeof(int));
-    int* cR = (int *)malloc((M+1)*sizeof(int));
 
     RowWiseInnerProduct(M, K, N, aD, aC, aR, bD, bC, bR, cD, cC, cR);
 
-    // for(int i=0; i<M+1; i++){
-    //     printf("%d\n", cR[i]);
-    //     for(int j=cR[i]; j<cR[i+1]; j++){
-    //         printf("%d %.f\n", cC[j], cD[j]);
-    //     }
-    // }
+    printf("Actual cNNZ = %d\n", cR[M]);
 
-    
-    // for(int i=0; i<M+1; i++){
-    //     for(int j=cR[i]; j<cR[i+1]; j++){
-    //         printf("%.f ", cD[j]);
-    //     }
-    //     printf("\n");
-    // }
-
-    printf("Actual cNNZ = %d \n", cR[M]);
-
-    free(aD);
-    free(aC);
-    free(aR);
-    free(bD);
-    free(bC);
-    free(bR);
-    free(cD);
-    free(cC);
-    free(cR);
+    free(aD); free(aC); free(aR);
+    free(bD); free(bC); free(bR);
+    free(cD); free(cC); free(cR);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
This PR fixes four memory safety bugs in `src/matmul/AxBRowIP.c` and adds a `CMakeLists.txt` so the project can be compiled with the standard `cmake .. && make` workflow.

## Bugs Fixed

**Bug 1 - undefined behaviour (malloc → calloc)**  
The per-row dense accumulator `cD_` was allocated with `malloc`, leaving garbage values in memory. Every `cD_[idx] += valA valB` was accumulating onto uninitialised data, producing incorrect SpGEMM results. Fixed by replacing with `calloc`, which zero-initialises.

**Bug 2 - memory leak**  
`cD_` was allocated inside the row loop but never freed. For a matrix with M rows this leaks N×4 bytes × M iterations gigabytes for large inputs. Fixed by adding `free(cD_)` at the end of each row iteration.

**Bug 3 - buffer overflow in output allocation**  
`cNNZ_estimation` used a density formula that can return a value smaller than the actual output NNZ, causing `cD[row_count]` and `cC[row_count]` to write past the end of their arrays (silent out-of-bounds write). Replaced with `safe_cNNZ(M, N) = M * N`, which is always a valid upper bound. A symbolic pre-count pass can be added later to get exact NNZ cheaply.

**Bug 4 - accumulator sized K instead of N**  
The accumulator `cD_` was sized `K` (columns of A), but it is indexed by output column (0..N-1). For non-square A×B this is incorrect. Fixed to use N.

## Added
- `CMakeLists.txt` targeting C11/C++17 with `-Wall -Wextra -O3`

## Tested
Compiled cleanly with GCC 11.4.0 and CMake 3.22.1 on Ubuntu 22.04 with zero errors and zero warnings.