### PR TITLE
Fix: Avoid underallocating sparse output buffers

### DIFF
--- a/src/matmul/AxBRowIP.c
+++ b/src/matmul/AxBRowIP.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 void RowWiseInnerProduct(const int M, const int K, const int N, float* aD, int* aC, int* aR, float* bD, int* bC, int* bR, float* cD, int* cC, int* cR){
+    (void)N;
     int row_count = 0;
     for(int row=0; row<M; row++){
         cR[row] = row_count;
@@ -61,6 +62,7 @@ int main(){
     const int aNNZ = gInfo[2];
     const int bNNZ = gInfo[2];
     const int rN   = gInfo[3];
+    (void)rN;
 
     float* aD = (float *)malloc(aNNZ*sizeof(float));
     int*   aC = (int *)malloc(aNNZ*sizeof(int));
@@ -113,11 +115,14 @@ int main(){
     fclose(file2);
     //////////////////////////////////////////
 
-    int cNNZ = cNNZ_estimation(M,K,N,aNNZ,bNNZ);
-    printf("Estimated cNNZ = %d \n", cNNZ);
+    int estimated_cNNZ = cNNZ_estimation(M,K,N,aNNZ,bNNZ);
+    size_t cNNZ_capacity = (size_t)M * (size_t)K;
+    printf("Estimated cNNZ = %d \n", estimated_cNNZ);
 
-    float* cD = (float *)malloc(cNNZ*sizeof(float));
-    int* cC = (int *)malloc(cNNZ*sizeof(int));
+    // Allocate the dense upper bound so the output buffers cannot overflow
+    // when the estimated cNNZ is lower than the actual result nnz.
+    float* cD = (float *)malloc(cNNZ_capacity*sizeof(float));
+    int* cC = (int *)malloc(cNNZ_capacity*sizeof(int));
     int* cR = (int *)malloc((M+1)*sizeof(int));
 
     RowWiseInnerProduct(M, K, N, aD, aC, aR, bD, bC, bR, cD, cC, cR);


### PR DESCRIPTION
## Summary

This PR fixes a possible output buffer underallocation in `src/matmul/AxBRowIP.c` from Issue #13 

Currently, `cD` and `cC` are allocated using `cNNZ_estimation()`. Since this value is only an estimate, some sparse matrix multiplication patterns can produce more non-zero values than the allocated capacity. In that case, `RowWiseInnerProduct()` may write past the allocated buffers while incrementing `row_count`.

## Changes

- Kept `cNNZ_estimation()` for reporting the estimated output NNZ.
- Allocated `cD` and `cC` using the dense upper bound `M * K` for the current implementation.
- Added a short comment explaining why the safer capacity is used.
- Marked currently unused variables with `(void)` to keep warning-enabled builds clean.

## Why

Sparse matrix multiplication can produce a denser result than the input matrices. So using an estimated NNZ as the actual allocation size can be unsafe unless the function also checks output capacity.

This change avoids possible out-of-bounds writes while keeping the existing multiplication logic unchanged.

## Testing

Built with warnings enabled:

```sh
gcc -Wall -Wextra -pedantic -o axb src/matmul/AxBRowIP.c
```
Also ran a smoke test with a temporary matrix_data/GeneralInfo.txt matching the checked-in CSR sample data:

```
Estimated cNNZ = 18
Actual cNNZ = 12
```