### PR TITLE
Consistency(AxBRowIP.c): Free general info allocation

### DIFF
--- a/src/matmul/AxBRowIP.c
+++ b/src/matmul/AxBRowIP.c
@@ -145,6 +145,7 @@ int main(){
     free(bD);
     free(bC);
     free(bR);
+    free(gInfo);
     free(cD);
     free(cC);
     free(cR);


### PR DESCRIPTION
Hi maintainers,

While reviewing `src/matmul/AxBRowIP.c`, I noticed that `gInfo` is allocated with `malloc`:

```c
int* gInfo = (int *)malloc(4*sizeof(int));
```

Most of the other allocated arrays in main() are freed before the program exits, but gInfo is not currently freed.

Since the program exits immediately after main(), the OS will reclaim this memory anyway. So this is not a serious leak in practice. I opened this as a small consistency cleanup because the file already explicitly frees the other allocations, and doing the same for gInfo keeps the cleanup style consistent.
