### PR TITLE
Add support for general CSR(A) x CSR(B) sparse matrix multiplication

### DIFF
--- a/matrices/example_rect_A/example_rect_A.mtx
+++ b/matrices/example_rect_A/example_rect_A.mtx
@@ -1,0 +1,5 @@
+%%MatrixMarket matrix coordinate real general
+2 3 3
+1 1 1.0
+1 3 2.0
+2 2 3.0

--- a/matrices/example_rect_B/example_rect_B.mtx
+++ b/matrices/example_rect_B/example_rect_B.mtx
@@ -1,0 +1,6 @@
+%%MatrixMarket matrix coordinate real general
+3 4 4
+1 2 5.0
+2 3 6.0
+3 1 7.0
+3 4 8.0

--- a/matrices/example_square_A/example_square_A.mtx
+++ b/matrices/example_square_A/example_square_A.mtx
@@ -1,0 +1,6 @@
+%%MatrixMarket matrix coordinate real general
+3 3 4
+1 1 1.0
+1 3 2.0
+2 2 3.0
+3 1 4.0

--- a/matrices/example_square_B/example_square_B.mtx
+++ b/matrices/example_square_B/example_square_B.mtx
@@ -1,0 +1,5 @@
+%%MatrixMarket matrix coordinate real general
+3 3 3
+1 2 5.0
+2 3 6.0
+3 1 7.0

--- a/scripts/cooTOcsr.py
+++ b/scripts/cooTOcsr.py
@@ -1,3 +1,6 @@
+import sys
+import os
+
 def ProcessMTX(mtx_path):
     matrix = []
     rows = []
@@ -33,12 +36,8 @@ def ProcessMTX(mtx_path):
                 cols.append(col_item-1)
                 values.append(val_item)
                 
-                # rc_value[f"{row_item}_{col_item}"] = val_item
                 rc_value[row_item] = [col_item, val_item]
     
-                # if row_item not in CSR_rowPtr:
-                #     CSR_rowPtr.append(
-                
                 if row_item in row_col:
                     row_col[row_item] += [col_item]
                 else:
@@ -49,10 +48,27 @@ def ProcessMTX(mtx_path):
                         row_col[col_item] += [row_item]
                     else:
                         row_col[col_item] = [row_item]
+                    
+                    # For SpGEMM, if symmetric, we also need to append the transposed entry.
+                    if row_item != col_item:
+                        rows.append(col_item-1)
+                        cols.append(row_item-1)
+                        values.append(val_item)
 
-    return rows,cols,values,no_of_rows,no_of_cols,NNZ_values
+    # Recalculate NNZ in case we appended symmetric entries
+    NNZ_values = len(rows)
+
+    return rows, cols, values, no_of_rows, no_of_cols, NNZ_values
 
 def coo_to_csr(coo_row, coo_col, coo_data, nrows):
+    # Zip, sort by row first, then by col, to ensure CSR column indices are sorted within each row.
+    # This solves the correctness bug where unordered COO yields unsorted CSR.
+    sorted_triplets = sorted(zip(coo_row, coo_col, coo_data), key=lambda x: (x[0], x[1]))
+    if sorted_triplets:
+        coo_row, coo_col, coo_data = zip(*sorted_triplets)
+    else:
+        coo_row, coo_col, coo_data = [], [], []
+
     # Initialize the CSR arrays
     csr_data = []
     csr_indices = []
@@ -61,13 +77,11 @@ def coo_to_csr(coo_row, coo_col, coo_data, nrows):
     # Count the non-zero elements in each row
     row_counts = [0] * (nrows+1)
     for row in coo_row:
-        # print(row)
         row_counts[row] += 1
 
     # Fill the csr_indptr array based on row_count
     for i in range(nrows):
         csr_indptr.append(csr_indptr[-1] + row_counts[i])
-    # print(csr_indptr)
 
     # Fill the csr_data and csr_indices arrays
     for i in range(len(coo_data)):
@@ -91,55 +105,107 @@ def coo_to_csr(coo_row, coo_col, coo_data, nrows):
     return csr_data, csr_indices, csr_indptr, reduced_indices
     
 
-def Main(matID):
-    matrix = ["patents_main",
-              "p2p-Gnutella31",
-              "roadNet-CA",
-              "webbase-1M",
-              "m133-b3",
-              "cit-Patents",
-              "mario002",
-              "web-Google",
-              "scircuit",
-              "amazon0312",
-              "ca-CondMat",
-              "email-Enron",
-              "wiki-Vote",
-              "cage12",
-              "2cubes_sphere",
-              "offshore",
-              "cop20k_A",
-              "filter3D",
-              "poisson3Da",
-              "example"]
+def Main(mat_A, mat_B):
+    matrix_list = ["patents_main",
+                   "p2p-Gnutella31",
+                   "roadNet-CA",
+                   "webbase-1M",
+                   "m133-b3",
+                   "cit-Patents",
+                   "mario002",
+                   "web-Google",
+                   "scircuit",
+                   "amazon0312",
+                   "ca-CondMat",
+                   "email-Enron",
+                   "wiki-Vote",
+                   "cage12",
+                   "2cubes_sphere",
+                   "offshore",
+                   "cop20k_A",
+                   "filter3D",
+                   "poisson3Da",
+                   "example"]
 
-    mtx_path = f"matrices/{matrix[matID]}/"+matrix[matID]+".mtx"
+    # Map numeric index to name if string is convertible to int and within range
+    try:
+        idx_A = int(mat_A)
+        if 0 <= idx_A < len(matrix_list):
+            mat_A = matrix_list[idx_A]
+    except ValueError:
+        pass
 
-    rows,cols,values,no_of_rows,no_of_cols,NNZ_values = ProcessMTX(mtx_path)
-    CSR_values,CSR_colIdx,CSR_rowPtr, CSR_redColIdx = coo_to_csr(rows,cols,values,no_of_rows)
+    try:
+        idx_B = int(mat_B)
+        if 0 <= idx_B < len(matrix_list):
+            mat_B = matrix_list[idx_B]
+    except ValueError:
+        pass
 
-    with open('matrix_data/CSR_values.txt', 'w') as f:
-        for item in CSR_values:
+    mtx_path_A = f"matrices/{mat_A}/{mat_A}.mtx"
+    mtx_path_B = f"matrices/{mat_B}/{mat_B}.mtx"
+
+    if not os.path.exists(mtx_path_A):
+        print(f"Error: Matrix A path {mtx_path_A} does not exist.")
+        return
+    if not os.path.exists(mtx_path_B):
+        print(f"Error: Matrix B path {mtx_path_B} does not exist.")
+        return
+
+    print(f"Processing Matrix A: {mtx_path_A}")
+    rows_A, cols_A, values_A, M, K_A, aNNZ = ProcessMTX(mtx_path_A)
+    CSR_values_A, CSR_colIdx_A, CSR_rowPtr_A, CSR_redColIdx_A = coo_to_csr(rows_A, cols_A, values_A, M)
+
+    print(f"Processing Matrix B: {mtx_path_B}")
+    rows_B, cols_B, values_B, K_B, N, bNNZ = ProcessMTX(mtx_path_B)
+    CSR_values_B, CSR_colIdx_B, CSR_rowPtr_B, CSR_redColIdx_B = coo_to_csr(rows_B, cols_B, values_B, K_B)
+
+    if K_A != K_B:
+        print(f"Warning: Dimensions mismatch for SpGEMM! A is {M}x{K_A}, B is {K_B}x{N}")
+
+    os.makedirs('matrix_data', exist_ok=True)
+
+    # Export Matrix A CSR
+    with open('matrix_data/A_values.txt', 'w') as f:
+        for item in CSR_values_A:
             f.write(f"{item}\n")
-        # f.write(f"{CSR_values}")
     
-    with open('matrix_data/CSR_colIdx.txt', 'w') as f:
-        for item in CSR_colIdx:
+    with open('matrix_data/A_colIdx.txt', 'w') as f:
+        for item in CSR_colIdx_A:
             f.write(f"{item}\n")
-        # f.write(f"{CSR_colIdx}")
     
-    with open('matrix_data/CSR_rowPtr.txt', 'w') as f:
-        for item in CSR_rowPtr:
+    with open('matrix_data/A_rowPtr.txt', 'w') as f:
+        for item in CSR_rowPtr_A:
             f.write(f"{item}\n")
-        # f.write(f"{CSR_rowPtr}")
+
+    # Export Matrix B CSR
+    with open('matrix_data/B_values.txt', 'w') as f:
+        for item in CSR_values_B:
+            f.write(f"{item}\n")
     
-    with open('matrix_data/CSR_redColIdx.txt', 'w') as f:
-        for item in CSR_redColIdx:
+    with open('matrix_data/B_colIdx.txt', 'w') as f:
+        for item in CSR_colIdx_B:
             f.write(f"{item}\n")
-        # f.write(f"{CSR_redColIdx}")
+    
+    with open('matrix_data/B_rowPtr.txt', 'w') as f:
+        for item in CSR_rowPtr_B:
+            f.write(f"{item}\n")
             
+    # Export GeneralInfo: M, K_A, N, aNNZ, bNNZ
     with open('matrix_data/GeneralInfo.txt', 'w') as f:
-        for item in [no_of_rows, no_of_cols, NNZ_values, max(CSR_redColIdx)+1]:
+        for item in [M, K_A, N, aNNZ, bNNZ]:
             f.write(f"{item}\n")
+    print(f"Successfully generated CSR matrices in matrix_data/: A ({M}x{K_A}, NNZ={aNNZ}), B ({K_B}x{N}, NNZ={bNNZ})")
 
-Main(11)
+if __name__ == "__main__":
+    if len(sys.argv) == 3:
+        Main(sys.argv[1], sys.argv[2])
+    elif len(sys.argv) == 2:
+        Main(sys.argv[1], sys.argv[1])
+    else:
+        # Default fallback to example if it exists, or email-Enron (which needs downloading).
+        # We'll default to 'example_square_A' and 'example_square_B' as our standard test matrices.
+        if os.path.exists("matrices/example_square_A/example_square_A.mtx"):
+            Main("example_square_A", "example_square_B")
+        else:
+            Main(11, 11)

--- a/src/matmul/AxBRowIP.c
+++ b/src/matmul/AxBRowIP.c
@@ -5,18 +5,19 @@ void RowWiseInnerProduct(const int M, const int K, const int N, float* aD, int* 
     int row_count = 0;
     for(int row=0; row<M; row++){
         cR[row] = row_count;
-        float* cD_ = (float *)calloc(K, sizeof(float));
+        // The accumulator size must match the column space of B (N), not K!
+        float* cD_ = (float *)calloc(N, sizeof(float));
         for(int col=aR[row]; col<aR[row+1]; col++){
             float valA = aD[col];
             for(int b_col=bR[aC[col]]; b_col<bR[aC[col]+1]; b_col++){
                 float valB = bD[b_col];
-                // int idx = row*K + bC[b_col];
                 int idx = bC[b_col];
                 cD_[idx] += valA * valB;
             }
         }
-        for (int i=0; i<K; i++){
-            if (cD_[i] != 0){
+        // Iterate through N (B's column space) instead of K!
+        for (int i=0; i<N; i++){
+            if (cD_[i] != 0.0f){
                 cC[row_count] = i;
                 cD[row_count] = cD_[i];
                 row_count++;
@@ -29,8 +30,20 @@ void RowWiseInnerProduct(const int M, const int K, const int N, float* aD, int* 
 
 float cNNZ_estimation(int M, int K, int N, int aNNZ, int bNNZ){
     long long MxK = (long long)M*(long long)K;
-    float density = (float)(aNNZ)/MxK + (float)(bNNZ)/MxK;
-    return density * M * N;
+    long long KxN = (long long)K*(long long)N;
+    float densityA = MxK > 0 ? (float)aNNZ / MxK : 0.0f;
+    float densityB = KxN > 0 ? (float)bNNZ / KxN : 0.0f;
+    float density = densityA + densityB;
+    if (density > 1.0f) density = 1.0f;
+    float est = density * M * N;
+
+    // Add safe lower and upper bounds
+    long long max_possible = (long long)M * (long long)N;
+    if (est < aNNZ) est = (float)aNNZ;
+    if (est < bNNZ) est = (float)bNNZ;
+    if (est > max_possible) est = (float)max_possible;
+    if (est < 10.0f) est = 10.0f;
+    return est;
 }
 
 int main(){
@@ -39,16 +52,17 @@ int main(){
     FILE *file2;
     FILE *file3;
 
-    int* gInfo = (int *)malloc(4*sizeof(int));
+    int* gInfo = (int *)malloc(5 * sizeof(int));
     //////////////////////////////////////////
     int number;
     file3 = fopen("matrix_data/GeneralInfo.txt", "r");
     if (file3 == NULL) {
-        perror("Error opening file");
+        perror("Error opening matrix_data/GeneralInfo.txt");
+        free(gInfo);
         return -1;
     }
     int idx = 0;
-    while (fscanf(file3, "%d", &number) == 1) {
+    while (fscanf(file3, "%d", &number) == 1 && idx < 5) {
         gInfo[idx] = number;
         idx++;
     }
@@ -57,10 +71,12 @@ int main(){
 
     const int M    = gInfo[0];
     const int K    = gInfo[1];
-    const int N    = gInfo[0];
-    const int aNNZ = gInfo[2];
-    const int bNNZ = gInfo[2];
-    const int rN   = gInfo[3];
+    const int N    = gInfo[2];
+    const int aNNZ = gInfo[3];
+    const int bNNZ = gInfo[4];
+
+    printf("Matrix A: %d x %d, NNZ = %d\n", M, K, aNNZ);
+    printf("Matrix B: %d x %d, NNZ = %d\n", K, N, bNNZ);
 
     float* aD = (float *)malloc(aNNZ*sizeof(float));
     int*   aC = (int *)malloc(aNNZ*sizeof(int));
@@ -71,49 +87,84 @@ int main(){
     int*   bR = (int *)malloc((K+1)*sizeof(int));
 
     //////////////////////////////////////////
+    // Load Matrix A CSR
     idx = 0;
-    file = fopen("matrix_data/CSR_values.txt", "r");
+    file = fopen("matrix_data/A_values.txt", "r");
     if (file == NULL) {
-        perror("Error opening file");
+        perror("Error opening matrix_data/A_values.txt");
         return -1;
     }
     float val;
-    while (fscanf(file, "%f", &val) == 1) {
+    while (fscanf(file, "%f", &val) == 1 && idx < aNNZ) {
         aD[idx] = val;
+        idx++;
+    }
+    fclose(file);
+
+    file1 = fopen("matrix_data/A_colIdx.txt", "r");
+    if (file1 == NULL) {
+        perror("Error opening matrix_data/A_colIdx.txt");
+        return -1;
+    }
+    idx = 0;
+    while (fscanf(file1, "%d", &number) == 1 && idx < aNNZ) {
+        aC[idx] = number;
+        idx++;
+    }
+    fclose(file1);
+
+    file2 = fopen("matrix_data/A_rowPtr.txt", "r");
+    if (file2 == NULL) {
+        perror("Error opening matrix_data/A_rowPtr.txt");
+        return -1;
+    }
+    idx = 0;
+    while (fscanf(file2, "%d", &number) == 1 && idx < M + 1) {
+        aR[idx] = number;
+        idx++;
+    }
+    fclose(file2);
+
+    //////////////////////////////////////////
+    // Load Matrix B CSR
+    idx = 0;
+    file = fopen("matrix_data/B_values.txt", "r");
+    if (file == NULL) {
+        perror("Error opening matrix_data/B_values.txt");
+        return -1;
+    }
+    while (fscanf(file, "%f", &val) == 1 && idx < bNNZ) {
         bD[idx] = val;
         idx++;
     }
     fclose(file);
 
-    //////////////////////////////////////////
-    file1 = fopen("matrix_data/CSR_colIdx.txt", "r");
+    file1 = fopen("matrix_data/B_colIdx.txt", "r");
     if (file1 == NULL) {
-        perror("Error opening file");
+        perror("Error opening matrix_data/B_colIdx.txt");
         return -1;
     }
     idx = 0;
-    while (fscanf(file1, "%d", &number) == 1) {
-        aC[idx] = number;
+    while (fscanf(file1, "%d", &number) == 1 && idx < bNNZ) {
         bC[idx] = number;
         idx++;
     }
     fclose(file1);
-    //////////////////////////////////////////
-    file2 = fopen("matrix_data/CSR_rowPtr.txt", "r");
+
+    file2 = fopen("matrix_data/B_rowPtr.txt", "r");
     if (file2 == NULL) {
-        perror("Error opening file");
+        perror("Error opening matrix_data/B_rowPtr.txt");
         return -1;
     }
     idx = 0;
-    while (fscanf(file2, "%d", &number) == 1) {
-        aR[idx] = number;
+    while (fscanf(file2, "%d", &number) == 1 && idx < K + 1) {
         bR[idx] = number;
         idx++;
     }
     fclose(file2);
     //////////////////////////////////////////
 
-    int cNNZ = cNNZ_estimation(M,K,N,aNNZ,bNNZ);
+    int cNNZ = (int)cNNZ_estimation(M,K,N,aNNZ,bNNZ);
     printf("Estimated cNNZ = %d \n", cNNZ);
 
     float* cD = (float *)malloc(cNNZ*sizeof(float));
@@ -122,23 +173,16 @@ int main(){
 
     RowWiseInnerProduct(M, K, N, aD, aC, aR, bD, bC, bR, cD, cC, cR);
 
-    // for(int i=0; i<M+1; i++){
-    //     printf("%d\n", cR[i]);
-    //     for(int j=cR[i]; j<cR[i+1]; j++){
-    //         printf("%d %.f\n", cC[j], cD[j]);
-    //     }
-    // }
-
-    
-    // for(int i=0; i<M+1; i++){
-    //     for(int j=cR[i]; j<cR[i+1]; j++){
-    //         printf("%.f ", cD[j]);
-    //     }
-    //     printf("\n");
-    // }
-
     printf("Actual cNNZ = %d \n", cR[M]);
 
+    printf("Resulting Matrix C (non-zero entries):\n");
+    for(int i=0; i<M; i++){
+        for(int j=cR[i]; j<cR[i+1]; j++){
+            printf("C[%d][%d] = %.2f\n", i, cC[j], cD[j]);
+        }
+    }
+
+    free(gInfo);
     free(aD);
     free(aC);
     free(aR);


### PR DESCRIPTION
Fixes #21

## Summary

This PR adds support for general CSR(A) × CSR(B) sparse matrix multiplication instead of assuming self-multiplication (`A × A`).

The current implementation in `AxBRowIP.c` loaded the same CSR files for both matrices and reused the same dimension metadata, which restricted the kernel to square self-multiplication workloads and caused incorrect handling for general rectangular SpGEMM cases.

---

## Changes

### General SpGEMM Support
- Added separate CSR export/import for matrices A and B
- Added support for independent:
  - dimensions (`M`, `K`, `N`)
  - NNZ counts (`aNNZ`, `bNNZ`)
  - CSR arrays for A and B

### Dimension & Correctness Fixes
- Fixed incorrect initialization of:
  - `N`
  - `bNNZ`
- Updated accumulator/output traversal to correctly iterate across `N` instead of `K`
- Added validation support for rectangular matrix multiplication

### COO → CSR Improvements
- Added sorting of COO entries before CSR conversion to ensure stable CSR row ordering
- This helps preserve correctness assumptions for future traversal/merge-based sparse optimizations

### Test Matrices
Added:
- square matrix examples
- rectangular matrix examples

for reproducible validation and testing.

---

## Validation

Tested successfully on:

- square matrix multiplication
- rectangular matrix multiplication

Verified example:

\[
(2 \times 3) \times (3 \times 4)
\rightarrow (2 \times 4)
\]

Example runtime output:

```text
Matrix A: 2 x 3, NNZ = 3
Matrix B: 3 x 4, NNZ = 4

Estimated cNNZ = 10
Actual cNNZ = 4

Resulting Matrix C (non-zero entries):
C[0][0] = 14.00
C[0][1] = 5.00
C[0][3] = 16.00
C[1][2] = 18.00
```
---
<img width="944" height="248" alt="Screenshot 2026-05-20 231024" src="https://github.com/user-attachments/assets/b27acbee-14bd-4834-b9b9-3e0354da24ce" />
