### PR TITLE
fix: N reads gInfo[1] (no_of_cols) not gInfo[0] — closes #23

### DIFF
--- a/src/matmul/AxBRowIP.c
+++ b/src/matmul/AxBRowIP.c
@@ -57,7 +57,7 @@ int main(){
 
     const int M    = gInfo[0];
     const int K    = gInfo[1];
-    const int N    = gInfo[0];
+    const int N    = gInfo[1];
     const int aNNZ = gInfo[2];
     const int bNNZ = gInfo[2];
     const int rN   = gInfo[3];


### PR DESCRIPTION
## Summary

- `N` was assigned `gInfo[0]` (same as `M`, `no_of_rows`) instead of `gInfo[1]` (`no_of_cols`)
- Every SpGEMM silently assumed a square M×M output regardless of actual matrix dimensions
- For non-square matrices: when N > K the output-flush loop exits early dropping valid non-zeros; when N < K it scans out-of-bounds into uninitialized accumulator memory

## Change

```c
// before
const int N = gInfo[0];

// after
const int N = gInfo[1];
```

One character change. `gInfo` is written by `cooTOcsr.py` in the order `[no_of_rows, no_of_cols, NNZ, max_redColIdx+1]`, so index 1 is the column count.

## Test plan

- [x] Run `cooTOcsr.py` on a rectangular matrix (e.g. `m133-b3` from the benchmark list)
- [x] Confirm `GeneralInfo.txt` has `no_of_rows != no_of_cols`
- [x] Run `AxBRowIP` and verify `Actual cNNZ` is non-zero and matches expected output size

Tested with `GeneralInfo.txt` set to M=4, K=6 (rectangular). Buggy `N=gInfo[0]=4` → `Estimated cNNZ=12`; fixed `N=gInfo[1]=6` → `Estimated cNNZ=18`. Output scales correctly with actual column count.

Closes #23