### PR TITLE
Add RVV INT8 and FP32 CSR SpGEMM backends

### DIFF
--- a/src/core/spgemm.c
+++ b/src/core/spgemm.c
@@ -62,6 +62,21 @@ rvsp_status_t rvsp_spgemm_csr(const rvsp_csr_matrix_t *A, const rvsp_csr_matrix_
         return rvsp_spgemm_csr_scalar_unroll4_f32(A, B, C);
     }
 
+    // RVV init kernels
+    if (backend == RVSP_BACKEND_RVV_INTRINSICS &&
+        A->dtype == RVSP_DTYPE_INT8 &&
+        B->dtype == RVSP_DTYPE_INT8)
+    {
+        return rvsp_spgemm_csr_rvv_i8_indexed_marked(A, B, C);
+    }
+
+    if (backend == RVSP_BACKEND_RVV_INTRINSICS &&
+        A->dtype == RVSP_DTYPE_FP32 &&
+        B->dtype == RVSP_DTYPE_FP32)
+    {
+        return rvsp_spgemm_csr_rvv_f32_indexed_marked(A, B, C);
+    }
+
     // default error
     return RVSP_ERROR_UNSUPPORTED_BACKEND;
 }

--- a/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
@@ -1,0 +1,50 @@
+#include <stdint.h>
+#include <stddef.h>
+
+#include "exp_raw_kernels.h"
+
+#if defined(__riscv_vector)
+#include <riscv_vector.h>
+#define EXP_HAVE_RVV_INTRINSICS 1
+#endif
+
+rvsp_status_t exp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz,
+                                                      const int32_t *b_col_idx,
+                                                      const float *b_values,
+                                                      float *acc)
+{
+    if (b_nnz < 0 || b_col_idx == NULL || b_values == NULL || acc == NULL)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+#if defined(EXP_HAVE_RVV_INTRINSICS)
+    int32_t p = 0;
+
+    while (p < b_nnz)
+    {
+        size_t vl = __riscv_vsetvl_e32m4((size_t)(b_nnz - p));
+
+        vfloat32m4_t vb = __riscv_vle32_v_f32m4(&b_values[p], vl);
+        vfloat32m4_t vprod = __riscv_vfmul_vf_f32m4(vb, a_val, vl);
+
+        vint32m4_t vidx_i32 = __riscv_vle32_v_i32m4(&b_col_idx[p], vl);
+        vint32m4_t voff_i32 = __riscv_vsll_vx_i32m4(vidx_i32, 2, vl);
+        vuint32m4_t voff_u32 = __riscv_vreinterpret_v_i32m4_u32m4(voff_i32);
+
+        vfloat32m4_t vacc = __riscv_vluxei32_v_f32m4(acc, voff_u32, vl);
+        vacc = __riscv_vfadd_vv_f32m4(vacc, vprod, vl);
+        __riscv_vsuxei32_v_f32m4(acc, voff_u32, vacc, vl);
+
+        p += (int32_t)vl;
+    }
+#else
+    for (int32_t p = 0; p < b_nnz; ++p)
+    {
+        int32_t col = b_col_idx[p];
+        acc[col] += a_val * b_values[p];
+    }
+#endif
+
+    return RVSP_SUCCESS;
+}

--- a/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
@@ -1,14 +1,14 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "exp_raw_kernels.h"
+#include "csr_spgemm_kernels.h"
 
 #if defined(__riscv_vector)
 #include <riscv_vector.h>
 #define EXP_HAVE_RVV_INTRINSICS 1
 #endif
 
-rvsp_status_t exp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz,
+rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz,
                                                       const int32_t *b_col_idx,
                                                       const float *b_values,
                                                       float *acc)

--- a/src/kernels/spgemm/accumulate_row_i8_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_i8_rvv_indexed_fast.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 rv-sparse contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Experimental RVV INT8 row accumulation microkernel.
+ * Fast indexed gather/scatter version.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "exp_raw_kernels.h"
+
+#if defined(__riscv_vector)
+#include <riscv_vector.h>
+#define EXP_HAVE_RVV_INTRINSICS 1
+#endif
+
+rvsp_status_t exp_accumulate_row_i8_rvv_indexed_fast(int8_t a_val, int32_t b_nnz, const int32_t *b_col_idx,
+                                                     const int8_t *b_values, int32_t *acc)
+{
+    if (!b_col_idx || !b_values || !acc)
+    {
+        return RVSP_ERROR_NULL_POINTER;
+    }
+
+    if (b_nnz < 0)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+#if defined(EXP_HAVE_RVV_INTRINSICS)
+    int32_t p = 0;
+
+    while (p < b_nnz)
+    {
+        size_t vl = __riscv_vsetvl_e8m1((size_t)(b_nnz - p));
+
+        vint8m1_t vb_i8 = __riscv_vle8_v_i8m1(&b_values[p], vl);
+
+        // INT8 x scalar INT8 -> INT16.
+        vint16m2_t vprod_i16 = __riscv_vwmul_vx_i16m2(vb_i8, a_val, vl);
+
+        // INT16 -> INT32.
+        vint32m4_t vprod_i32 = __riscv_vwadd_vx_i32m4(vprod_i16, (int16_t)0, vl);
+        vint32m4_t vcols_i32 = __riscv_vle32_v_i32m4(&b_col_idx[p], vl);
+
+        // offset = col * sizeof(int32_t)
+        vuint32m4_t vcols_u32 = __riscv_vreinterpret_v_i32m4_u32m4(vcols_i32);
+
+        vuint32m4_t voffsets = __riscv_vsll_vx_u32m4(vcols_u32, 2, vl);
+        // Gather acc[col].
+        vint32m4_t vacc = __riscv_vluxei32_v_i32m4(acc, voffsets, vl);
+
+        // acc[col] += product.
+        vint32m4_t vsum = __riscv_vadd_vv_i32m4(vacc, vprod_i32, vl);
+
+        __riscv_vsuxei32_v_i32m4(acc, voffsets, vsum, vl);
+
+        p += (int32_t)vl;
+    }
+#else
+    for (int32_t p = 0; p < b_nnz; p++)
+    {
+        int32_t col = b_col_idx[p];
+        acc[col] += (int32_t)a_val * (int32_t)b_values[p];
+    }
+#endif
+
+    return RVSP_SUCCESS;
+}

--- a/src/kernels/spgemm/accumulate_row_i8_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_i8_rvv_indexed_fast.c
@@ -10,14 +10,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "exp_raw_kernels.h"
+#include "csr_spgemm_kernels.h"
 
 #if defined(__riscv_vector)
 #include <riscv_vector.h>
 #define EXP_HAVE_RVV_INTRINSICS 1
 #endif
 
-rvsp_status_t exp_accumulate_row_i8_rvv_indexed_fast(int8_t a_val, int32_t b_nnz, const int32_t *b_col_idx,
+rvsp_status_t rvsp_accumulate_row_i8_rvv_indexed_fast(int8_t a_val, int32_t b_nnz, const int32_t *b_col_idx,
                                                      const int8_t *b_values, int32_t *acc)
 {
     if (!b_col_idx || !b_values || !acc)

--- a/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stddef.h>
-#include "exp_raw_kernels.h"
+#include "csr_spgemm_kernels.h"
 
 static int compare_i32_f32(const void *a, const void *b)
 {
@@ -48,7 +48,7 @@ static int reserve_f32_output_capacity_marked(int32_t **col_idx, float **values,
     return 0;
 }
 
-rvsp_status_t exp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
                                                         const int32_t *a_row_ptr, const int32_t *a_col_idx,
                                                         const float *a_values, const int32_t *b_row_ptr,
                                                         const int32_t *b_col_idx, const float *b_values,
@@ -136,7 +136,7 @@ rvsp_status_t exp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t 
             int32_t a_col = a_col_idx[ap];
             float a_val = a_values[ap];
 
-            rvsp_status_t status = exp_accumulate_row_f32_rvv_indexed_fast(
+            rvsp_status_t status = rvsp_accumulate_row_f32_rvv_indexed_fast(
                 a_val,
                 b_row_ptr[a_col + 1] - b_row_ptr[a_col],
                 &b_col_idx[b_row_ptr[a_col]],

--- a/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
@@ -1,0 +1,200 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include "exp_raw_kernels.h"
+
+static int compare_i32_f32(const void *a, const void *b)
+{
+    int32_t ia = *(const int32_t *)a;
+    int32_t ib = *(const int32_t *)b;
+
+    if (ia < ib)
+        return -1;
+    if (ia > ib)
+        return 1;
+    return 0;
+}
+
+static int reserve_f32_output_capacity_marked(int32_t **col_idx, float **values, int32_t *capacity, int32_t required)
+{
+    if (required <= *capacity)
+    {
+        return 0;
+    }
+
+    int32_t new_capacity = (*capacity == 0) ? 16 : *capacity;
+
+    while (new_capacity < required)
+    {
+        new_capacity *= 2;
+    }
+
+    int32_t *new_col_idx = (int32_t *)realloc(*col_idx, (size_t)new_capacity * sizeof(int32_t));
+    if (new_col_idx == NULL)
+    {
+        return -1;
+    }
+
+    float *new_values = (float *)realloc(*values, (size_t)new_capacity * sizeof(float));
+    if (new_values == NULL)
+    {
+        return -1;
+    }
+
+    *col_idx = new_col_idx;
+    *values = new_values;
+    *capacity = new_capacity;
+
+    return 0;
+}
+
+rvsp_status_t exp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
+                                                        const int32_t *a_row_ptr, const int32_t *a_col_idx,
+                                                        const float *a_values, const int32_t *b_row_ptr,
+                                                        const int32_t *b_col_idx, const float *b_values,
+                                                        int32_t **c_row_ptr_out, int32_t **c_col_idx_out,
+                                                        float **c_values_out, int32_t *c_nnz_out)
+{
+    if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
+        a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
+        b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
+        c_row_ptr_out == NULL || c_col_idx_out == NULL ||
+        c_values_out == NULL || c_nnz_out == NULL)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
+    float *acc = (float *)calloc((size_t)b_cols, sizeof(float));
+    int32_t *marker = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+    int32_t *touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+
+    if (c_row_ptr == NULL || acc == NULL || marker == NULL || touched == NULL)
+    {
+        free(c_row_ptr);
+        free(acc);
+        free(marker);
+        free(touched);
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    for (int32_t col = 0; col < b_cols; ++col)
+    {
+        marker[col] = -1;
+    }
+
+    int32_t *c_col_idx = NULL;
+    float *c_values = NULL;
+    int32_t capacity = 0;
+    int32_t nnz_count = 0;
+
+    for (int32_t i = 0; i < a_rows; ++i)
+    {
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_row_ptr[i]; ap < a_row_ptr[i + 1]; ++ap)
+        {
+            int32_t a_col = a_col_idx[ap];
+
+            if (a_col < 0 || a_col >= a_cols)
+            {
+                free(c_row_ptr);
+                free(c_col_idx);
+                free(c_values);
+                free(acc);
+                free(marker);
+                free(touched);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            for (int32_t bp = b_row_ptr[a_col]; bp < b_row_ptr[a_col + 1]; ++bp)
+            {
+                int32_t col = b_col_idx[bp];
+
+                if (col < 0 || col >= b_cols)
+                {
+                    free(c_row_ptr);
+                    free(c_col_idx);
+                    free(c_values);
+                    free(acc);
+                    free(marker);
+                    free(touched);
+                    return RVSP_ERROR_INVALID_ARGUMENT;
+                }
+
+                if (marker[col] != i)
+                {
+                    marker[col] = i;
+                    acc[col] = 0.0f;
+                    touched[touched_count++] = col;
+                }
+            }
+        }
+
+        for (int32_t ap = a_row_ptr[i]; ap < a_row_ptr[i + 1]; ++ap)
+        {
+            int32_t a_col = a_col_idx[ap];
+            float a_val = a_values[ap];
+
+            rvsp_status_t status = exp_accumulate_row_f32_rvv_indexed_fast(
+                a_val,
+                b_row_ptr[a_col + 1] - b_row_ptr[a_col],
+                &b_col_idx[b_row_ptr[a_col]],
+                &b_values[b_row_ptr[a_col]],
+                acc);
+
+            if (status != RVSP_SUCCESS)
+            {
+                free(c_row_ptr);
+                free(c_col_idx);
+                free(c_values);
+                free(acc);
+                free(marker);
+                free(touched);
+                return status;
+            }
+        }
+
+        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_f32);
+
+        for (int32_t t = 0; t < touched_count; ++t)
+        {
+            int32_t col = touched[t];
+
+            if (acc[col] != 0.0f)
+            {
+                if (reserve_f32_output_capacity_marked(
+                        &c_col_idx,
+                        &c_values,
+                        &capacity,
+                        nnz_count + 1) != 0)
+                {
+                    free(c_row_ptr);
+                    free(c_col_idx);
+                    free(c_values);
+                    free(acc);
+                    free(marker);
+                    free(touched);
+                    return RVSP_ERROR_INVALID_ARGUMENT;
+                }
+
+                c_col_idx[nnz_count] = col;
+                c_values[nnz_count] = acc[col];
+                nnz_count++;
+            }
+        }
+
+        c_row_ptr[i + 1] = nnz_count;
+    }
+
+    free(acc);
+    free(marker);
+    free(touched);
+
+    *c_row_ptr_out = c_row_ptr;
+    *c_col_idx_out = c_col_idx;
+    *c_values_out = c_values;
+    *c_nnz_out = nnz_count;
+
+    return RVSP_SUCCESS;
+}

--- a/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "exp_raw_kernels.h"
+#include "csr_spgemm_kernels.h"
 
 static int compare_i32(const void *a, const void *b)
 {
@@ -73,7 +73,7 @@ static rvsp_status_t reserve_output_capacity(int32_t **col_idx, int32_t **values
     return RVSP_SUCCESS;
 }
 
-rvsp_status_t exp_spgemm_csr_rvv_i8_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
+rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
                                                        const int32_t *a_row_ptr, const int32_t *a_col_idx,
                                                        const int8_t *a_values, const int32_t *b_row_ptr,
                                                        const int32_t *b_col_idx, const int8_t *b_values,
@@ -179,7 +179,7 @@ rvsp_status_t exp_spgemm_csr_rvv_i8_indexed_marked_raw(int32_t a_rows, int32_t a
                 }
             }
 
-            rvsp_status_t status = exp_accumulate_row_i8_rvv_indexed_fast(a_values[a_pos], b_end - b_start,
+            rvsp_status_t status = rvsp_accumulate_row_i8_rvv_indexed_fast(a_values[a_pos], b_end - b_start,
                                                                           &b_col_idx[b_start], &b_values[b_start],
                                                                           acc);
 

--- a/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2026 rv-sparse contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Experimental optimized CSR SpGEMM RVV INT8 raw kernel.
+ *
+ * Computes INT8 x INT8 with INT32 accumulation/output.
+ *
+ * Optimization strategy:
+ * - Reuse one dense accumulator across rows.
+ * - Track touched columns using marker/touched arrays.
+ * - Avoid scanning all B columns when constructing each output row.
+ * - Use RVV indexed gather/scatter for row accumulation.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "exp_raw_kernels.h"
+
+static int compare_i32(const void *a, const void *b)
+{
+    int32_t x = *(const int32_t *)a;
+    int32_t y = *(const int32_t *)b;
+
+    return (x > y) - (x < y);
+}
+
+static rvsp_status_t reserve_output_capacity(int32_t **col_idx, int32_t **values,
+                                             int32_t *capacity,
+                                             int32_t required)
+{
+    if (required <= *capacity)
+    {
+        return RVSP_SUCCESS;
+    }
+
+    int32_t new_capacity = *capacity > 0 ? *capacity : 64;
+
+    while (new_capacity < required)
+    {
+        if (new_capacity > INT32_MAX / 2)
+        {
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+
+        new_capacity *= 2;
+    }
+
+    int32_t *new_col_idx = (int32_t *)realloc(
+        *col_idx,
+        (size_t)new_capacity * sizeof(int32_t));
+
+    if (!new_col_idx)
+    {
+        return RVSP_ERROR_ALLOCATION_FAILED;
+    }
+
+    int32_t *new_values = (int32_t *)realloc(
+        *values,
+        (size_t)new_capacity * sizeof(int32_t));
+
+    if (!new_values)
+    {
+        return RVSP_ERROR_ALLOCATION_FAILED;
+    }
+
+    *col_idx = new_col_idx;
+    *values = new_values;
+    *capacity = new_capacity;
+
+    return RVSP_SUCCESS;
+}
+
+rvsp_status_t exp_spgemm_csr_rvv_i8_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
+                                                       const int32_t *a_row_ptr, const int32_t *a_col_idx,
+                                                       const int8_t *a_values, const int32_t *b_row_ptr,
+                                                       const int32_t *b_col_idx, const int8_t *b_values,
+                                                       int32_t **c_row_ptr_out, int32_t **c_col_idx_out,
+                                                       int32_t **c_values_out, int32_t *c_nnz_out)
+{
+    if (!a_row_ptr || !a_col_idx || !a_values ||
+        !b_row_ptr || !b_col_idx || !b_values ||
+        !c_row_ptr_out || !c_col_idx_out ||
+        !c_values_out || !c_nnz_out)
+    {
+        return RVSP_ERROR_NULL_POINTER;
+    }
+
+    if (a_rows <= 0 || a_cols <= 0 || b_cols <= 0)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
+
+    int32_t output_capacity = 64;
+    int32_t *c_col_idx = (int32_t *)malloc((size_t)output_capacity * sizeof(int32_t));
+    int32_t *c_values = (int32_t *)malloc((size_t)output_capacity * sizeof(int32_t));
+
+    int32_t *acc = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+    int32_t *marker = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+    int32_t *touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+
+    if (!c_row_ptr || !c_col_idx || !c_values || !acc || !marker || !touched)
+    {
+        free(c_row_ptr);
+        free(c_col_idx);
+        free(c_values);
+        free(acc);
+        free(marker);
+        free(touched);
+        return RVSP_ERROR_ALLOCATION_FAILED;
+    }
+
+    for (int32_t col = 0; col < b_cols; col++)
+    {
+        marker[col] = -1;
+        acc[col] = 0;
+    }
+
+    int32_t nnz_count = 0;
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        c_row_ptr[row] = nnz_count;
+
+        int32_t touched_count = 0;
+
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+
+        for (int32_t a_pos = a_start; a_pos < a_end; a_pos++)
+        {
+            int32_t k = a_col_idx[a_pos];
+
+            if (k < 0 || k >= a_cols)
+            {
+                free(c_row_ptr);
+                free(c_col_idx);
+                free(c_values);
+                free(acc);
+                free(marker);
+                free(touched);
+                return RVSP_ERROR_INVALID_CSR;
+            }
+
+            int32_t b_start = b_row_ptr[k];
+            int32_t b_end = b_row_ptr[k + 1];
+
+            /*
+             * Prepass:
+             * - validate columns
+             * - register touched columns
+             * - initialize accumulator entries for the current row
+             */
+            for (int32_t b_pos = b_start; b_pos < b_end; b_pos++)
+            {
+                int32_t col = b_col_idx[b_pos];
+
+                if (col < 0 || col >= b_cols)
+                {
+                    free(c_row_ptr);
+                    free(c_col_idx);
+                    free(c_values);
+                    free(acc);
+                    free(marker);
+                    free(touched);
+                    return RVSP_ERROR_INVALID_CSR;
+                }
+
+                if (marker[col] != row)
+                {
+                    marker[col] = row;
+                    touched[touched_count] = col;
+                    touched_count++;
+                    acc[col] = 0;
+                }
+            }
+
+            rvsp_status_t status = exp_accumulate_row_i8_rvv_indexed_fast(a_values[a_pos], b_end - b_start,
+                                                                          &b_col_idx[b_start], &b_values[b_start],
+                                                                          acc);
+
+            if (status != RVSP_SUCCESS)
+            {
+                free(c_row_ptr);
+                free(c_col_idx);
+                free(c_values);
+                free(acc);
+                free(marker);
+                free(touched);
+                return status;
+            }
+        }
+
+        // Keep output deterministic and comparable with the scalar reference.
+        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32);
+
+        rvsp_status_t status = reserve_output_capacity(&c_col_idx, &c_values,
+                                                       &output_capacity, nnz_count + touched_count);
+
+        if (status != RVSP_SUCCESS)
+        {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(marker);
+            free(touched);
+            return status;
+        }
+
+        for (int32_t i = 0; i < touched_count; i++)
+        {
+            int32_t col = touched[i];
+
+            if (acc[col] != 0)
+            {
+                c_col_idx[nnz_count] = col;
+                c_values[nnz_count] = acc[col];
+                nnz_count++;
+            }
+        }
+    }
+
+    c_row_ptr[a_rows] = nnz_count;
+
+    int32_t *final_col_idx = (int32_t *)realloc(
+        c_col_idx,
+        (size_t)nnz_count * sizeof(int32_t));
+
+    if (final_col_idx)
+    {
+        c_col_idx = final_col_idx;
+    }
+
+    int32_t *final_values = (int32_t *)realloc(
+        c_values,
+        (size_t)nnz_count * sizeof(int32_t));
+
+    if (final_values)
+    {
+        c_values = final_values;
+    }
+
+    free(acc);
+    free(marker);
+    free(touched);
+
+    *c_row_ptr_out = c_row_ptr;
+    *c_col_idx_out = c_col_idx;
+    *c_values_out = c_values;
+    *c_nnz_out = nnz_count;
+
+    return RVSP_SUCCESS;
+}

--- a/src/kernels/spgemm/csr_spgemm_kernels.h
+++ b/src/kernels/spgemm/csr_spgemm_kernels.h
@@ -40,7 +40,6 @@ rvsp_status_t rvsp_spgemm_csr_scalar_unroll4_f32(
 /*
  * Raw kernel layer:
  * Uses plain pointers and dimensions.
- * This is the layer we optimize and port to RISC-V/RVV.
  */
 
 rvsp_status_t rvsp_spgemm_csr_scalar_i8_raw(
@@ -87,5 +86,60 @@ rvsp_status_t rvsp_spgemm_csr_scalar_unroll4_f32_raw(
     int32_t **c_col_idx_out,
     float **c_values_out,
     int32_t *c_nnz_out);
+
+// This is the layer we optimize and port to RISC-V/RVV.
+rvsp_status_t rvsp_accumulate_row_i8_rvv_indexed_fast(
+    int8_t a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const int8_t *b_values,
+    int32_t *acc);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const int8_t *a_values,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    const int8_t *b_values,
+    int32_t **c_row_ptr_out,
+    int32_t **c_col_idx_out,
+    int32_t **c_values_out,
+    int32_t *c_nnz_out);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C);
+
+rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(
+    float a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const float *b_values,
+    float *acc);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const float *a_values,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    const float *b_values,
+    int32_t **c_row_ptr_out,
+    int32_t **c_col_idx_out,
+    float **c_values_out,
+    int32_t *c_nnz_out);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C);
 
 #endif /*RVSP_CSR_SPGEMM_KERNELS_H*/

--- a/src/kernels/spgemm/csr_spgemm_wrappers.c
+++ b/src/kernels/spgemm/csr_spgemm_wrappers.c
@@ -231,3 +231,116 @@ rvsp_status_t rvsp_spgemm_csr_scalar_unroll4_f32(const rvsp_csr_matrix_t *A, con
 
     return RVSP_SUCCESS;
 }
+
+// wrapper for i8_indexed
+rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C)
+{
+    if (A == NULL || B == NULL || C == NULL)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->dtype != RVSP_DTYPE_INT8 || B->dtype != RVSP_DTYPE_INT8)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->cols != B->rows)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    int32_t *c_row_ptr = NULL;
+    int32_t *c_col_idx = NULL;
+    int32_t *c_values = NULL;
+    int32_t c_nnz = 0;
+
+    rvsp_status_t status = rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
+        A->rows,
+        A->cols,
+        B->cols,
+        A->row_ptr,
+        A->col_idx,
+        (const int8_t *)A->values,
+        B->row_ptr,
+        B->col_idx,
+        (const int8_t *)B->values,
+        &c_row_ptr,
+        &c_col_idx,
+        &c_values,
+        &c_nnz);
+
+    if (status != RVSP_SUCCESS)
+    {
+        return status;
+    }
+
+    C->rows = A->rows;
+    C->cols = B->cols;
+    C->nnz = c_nnz;
+    C->row_ptr = c_row_ptr;
+    C->col_idx = c_col_idx;
+    C->values = c_values;
+    C->dtype = RVSP_DTYPE_INT32;
+
+    return RVSP_SUCCESS;
+}
+
+// wrapper for f32_indexed
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked(const rvsp_csr_matrix_t *A,
+                                                     const rvsp_csr_matrix_t *B,
+                                                     rvsp_csr_matrix_t *C)
+{
+    if (A == NULL || B == NULL || C == NULL)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->dtype != RVSP_DTYPE_FP32 || B->dtype != RVSP_DTYPE_FP32)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->cols != B->rows)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    int32_t *c_row_ptr = NULL;
+    int32_t *c_col_idx = NULL;
+    float *c_values = NULL;
+    int32_t c_nnz = 0;
+
+    rvsp_status_t status = rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
+        A->rows,
+        A->cols,
+        B->cols,
+        A->row_ptr,
+        A->col_idx,
+        (const float *)A->values,
+        B->row_ptr,
+        B->col_idx,
+        (const float *)B->values,
+        &c_row_ptr,
+        &c_col_idx,
+        &c_values,
+        &c_nnz);
+
+    if (status != RVSP_SUCCESS)
+    {
+        return status;
+    }
+
+    C->rows = A->rows;
+    C->cols = B->cols;
+    C->nnz = c_nnz;
+    C->row_ptr = c_row_ptr;
+    C->col_idx = c_col_idx;
+    C->values = c_values;
+    C->dtype = RVSP_DTYPE_FP32;
+
+    return RVSP_SUCCESS;
+}


### PR DESCRIPTION
## Summary

This PR adds RISC-V Vector CSR SpGEMM backends for INT8 and FP32 through the public API.

The new backends are connected through `RVSP_BACKEND_RVV_INTRINSICS` and currently use the indexed marked accumulation strategy developed in the experimental raw-kernel workspace.

## Changes

* Adds RVV INT8 CSR SpGEMM backend.
* Adds RVV FP32 CSR SpGEMM backend.
* Adds RVV indexed accumulation helpers for INT8 and FP32.
* Connects the RVV backends to the public dispatcher.
* Adds wrapper functions that expose the raw kernels through `rvsp_csr_matrix_t`.

## Supported operations

```text
INT8  x INT8  -> INT32
FP32  x FP32  -> FP32
```

## Backend selection

The new kernels are selected using:

```c
options.backend = RVSP_BACKEND_RVV_INTRINSICS;
```

## Notes

These kernels are migrated from the experimental raw-kernel implementation after correctness validation in the experimental workspace.

The implementation is intended for RISC-V targets with RVV support. Final performance evaluation should be performed on real RISC-V hardware.

## Testing

The following tests were run:

```bash
make clean
make test

make clean
make test TARGET_ARCH=riscv
```

## Public API impact

No public API function signatures were changed.

The PR adds support for new backend dispatch paths using the existing `RVSP_BACKEND_RVV_INTRINSICS` backend option.
