### PR TITLE
Add FP64 and improve RVV CSR SpGEMM backends

### DIFF
--- a/include/rv_sparse_types.h
+++ b/include/rv_sparse_types.h
@@ -34,7 +34,8 @@ extern "C"
         RVSP_DTYPE_INT8,
         RVSP_DTYPE_INT32,
         RVSP_DTYPE_BF16,
-        RVSP_DTYPE_FP32
+        RVSP_DTYPE_FP32,
+        RVSP_DTYPE_FP64
     } rvsp_dtype_t;
 
     typedef enum

--- a/src/core/spgemm.c
+++ b/src/core/spgemm.c
@@ -14,7 +14,7 @@
 
 /*Note:
  * this is a basic dispacher, inspired in blas, from her the library decided what kernel use
- * in revision
+ * under revision
  * todo things :  structure for add new kernels easily..
  */
 
@@ -55,6 +55,13 @@ rvsp_status_t rvsp_spgemm_csr(const rvsp_csr_matrix_t *A, const rvsp_csr_matrix_
         return rvsp_spgemm_csr_scalar_i8(A, B, C);
     }
 
+    if (backend == RVSP_BACKEND_SCALAR &&
+        input_dtype == RVSP_DTYPE_FP64 &&
+        output_dtype == RVSP_DTYPE_FP64)
+    {
+        return rvsp_spgemm_csr_scalar_f64(A, B, C);
+    }
+
     if (backend == RVSP_BACKEND_SCALAR_UNROLL4 &&
         input_dtype == RVSP_DTYPE_FP32 &&
         output_dtype == RVSP_DTYPE_FP32)
@@ -75,6 +82,13 @@ rvsp_status_t rvsp_spgemm_csr(const rvsp_csr_matrix_t *A, const rvsp_csr_matrix_
         B->dtype == RVSP_DTYPE_FP32)
     {
         return rvsp_spgemm_csr_rvv_f32_indexed_marked(A, B, C);
+    }
+
+    if (backend == RVSP_BACKEND_RVV_INTRINSICS &&
+        A->dtype == RVSP_DTYPE_FP64 &&
+        B->dtype == RVSP_DTYPE_FP64)
+    {
+        return rvsp_spgemm_csr_rvv_f64_indexed_marked(A, B, C);
     }
 
     // default error

--- a/src/kernels/spgemm/accumulate_row_f64_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f64_rvv_indexed_fast.c
@@ -1,0 +1,50 @@
+#include <stdint.h>
+#include <stddef.h>
+
+#include "csr_spgemm_kernels.h"
+
+#if defined(__riscv_vector)
+#include <riscv_vector.h>
+#define RVSP_HAVE_RVV_INTRINSICS 1
+#endif
+
+rvsp_status_t rvsp_accumulate_row_f64_rvv_indexed_fast(
+    double a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const double *b_values,
+    double *acc
+)
+{
+    if (b_nnz < 0 || b_col_idx == NULL || b_values == NULL || acc == NULL) {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+    int32_t p = 0;
+
+    while (p < b_nnz) {
+        size_t vl = __riscv_vsetvl_e64m4((size_t)(b_nnz - p));
+
+        vfloat64m4_t vb = __riscv_vle64_v_f64m4(&b_values[p], vl);
+        vfloat64m4_t vprod = __riscv_vfmul_vf_f64m4(vb, a_val, vl);
+
+        vint32m2_t vidx_i32 = __riscv_vle32_v_i32m2(&b_col_idx[p], vl);
+        vint32m2_t voff_i32 = __riscv_vsll_vx_i32m2(vidx_i32, 3, vl);
+        vuint32m2_t voff_u32 = __riscv_vreinterpret_v_i32m2_u32m2(voff_i32);
+
+        vfloat64m4_t vacc = __riscv_vluxei32_v_f64m4(acc, voff_u32, vl);
+        vacc = __riscv_vfadd_vv_f64m4(vacc, vprod, vl);
+        __riscv_vsuxei32_v_f64m4(acc, voff_u32, vacc, vl);
+
+        p += (int32_t)vl;
+    }
+#else
+    for (int32_t p = 0; p < b_nnz; p++) {
+        int32_t col = b_col_idx[p];
+        acc[col] += a_val * b_values[p];
+    }
+#endif
+
+    return RVSP_SUCCESS;
+}

--- a/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
@@ -9,13 +9,11 @@ static int compare_i32_rvv_f32(const void *a, const void *b)
     int32_t ia = *(const int32_t *)a;
     int32_t ib = *(const int32_t *)b;
 
-    if (ia < ib)
-    {
+    if (ia < ib) {
         return -1;
     }
 
-    if (ia > ib)
-    {
+    if (ia > ib) {
         return 1;
     }
 
@@ -26,10 +24,10 @@ static void clear_f32_workspace(
     float *acc,
     uint8_t *mark,
     const int32_t *touched,
-    int32_t touched_count)
+    int32_t touched_count
+)
 {
-    for (int32_t i = 0; i < touched_count; i++)
-    {
+    for (int32_t i = 0; i < touched_count; i++) {
         int32_t col = touched[i];
         acc[col] = 0.0f;
         mark[col] = 0;
@@ -43,19 +41,17 @@ static rvsp_status_t mark_f32_row_columns(
     float *acc,
     uint8_t *mark,
     int32_t *touched,
-    int32_t *touched_count)
+    int32_t *touched_count
+)
 {
-    for (int32_t p = 0; p < b_nnz; p++)
-    {
+    for (int32_t p = 0; p < b_nnz; p++) {
         int32_t col = b_col_idx[p];
 
-        if (col < 0 || col >= b_cols)
-        {
+        if (col < 0 || col >= b_cols) {
             return RVSP_ERROR_INVALID_ARGUMENT;
         }
 
-        if (mark[col] == 0)
-        {
+        if (mark[col] == 0) {
             mark[col] = 1;
             touched[*touched_count] = col;
             (*touched_count)++;
@@ -75,19 +71,17 @@ static rvsp_status_t accumulate_f32_row_scalar_marked(
     float *acc,
     uint8_t *mark,
     int32_t *touched,
-    int32_t *touched_count)
+    int32_t *touched_count
+)
 {
-    for (int32_t p = 0; p < b_nnz; p++)
-    {
+    for (int32_t p = 0; p < b_nnz; p++) {
         int32_t col = b_col_idx[p];
 
-        if (col < 0 || col >= b_cols)
-        {
+        if (col < 0 || col >= b_cols) {
             return RVSP_ERROR_INVALID_ARGUMENT;
         }
 
-        if (mark[col] == 0)
-        {
+        if (mark[col] == 0) {
             mark[col] = 1;
             touched[*touched_count] = col;
             (*touched_count)++;
@@ -105,31 +99,28 @@ static rvsp_status_t build_b_duplicate_flags_f32(
     int32_t b_cols,
     const int32_t *b_row_ptr,
     const int32_t *b_col_idx,
-    uint8_t *b_has_duplicates)
+    uint8_t *b_has_duplicates
+)
 {
     uint8_t *seen = NULL;
     int32_t *seen_touched = NULL;
 
-    if (b_cols > 0)
-    {
+    if (b_cols > 0) {
         seen = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
         seen_touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
 
-        if (seen == NULL || seen_touched == NULL)
-        {
+        if (seen == NULL || seen_touched == NULL) {
             free(seen);
             free(seen_touched);
             return RVSP_ERROR_ALLOCATION_FAILED;
         }
     }
 
-    for (int32_t row = 0; row < b_rows; row++)
-    {
+    for (int32_t row = 0; row < b_rows; row++) {
         int32_t start = b_row_ptr[row];
         int32_t end = b_row_ptr[row + 1];
 
-        if (start < 0 || end < start)
-        {
+        if (start < 0 || end < start) {
             free(seen);
             free(seen_touched);
             return RVSP_ERROR_INVALID_ARGUMENT;
@@ -137,14 +128,11 @@ static rvsp_status_t build_b_duplicate_flags_f32(
 
         int32_t seen_count = 0;
 
-        for (int32_t p = start; p < end; p++)
-        {
+        for (int32_t p = start; p < end; p++) {
             int32_t col = b_col_idx[p];
 
-            if (col < 0 || col >= b_cols)
-            {
-                for (int32_t i = 0; i < seen_count; i++)
-                {
+            if (col < 0 || col >= b_cols) {
+                for (int32_t i = 0; i < seen_count; i++) {
                     seen[seen_touched[i]] = 0;
                 }
 
@@ -153,20 +141,16 @@ static rvsp_status_t build_b_duplicate_flags_f32(
                 return RVSP_ERROR_INVALID_ARGUMENT;
             }
 
-            if (seen[col] != 0)
-            {
+            if (seen[col] != 0) {
                 b_has_duplicates[row] = 1;
-            }
-            else
-            {
+            } else {
                 seen[col] = 1;
                 seen_touched[seen_count] = col;
                 seen_count++;
             }
         }
 
-        for (int32_t i = 0; i < seen_count; i++)
-        {
+        for (int32_t i = 0; i < seen_count; i++) {
             seen[seen_touched[i]] = 0;
         }
     }
@@ -187,10 +171,10 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
     uint8_t *mark,
     int32_t *touched,
     int32_t *touched_count,
-    uint8_t has_duplicates)
+    uint8_t has_duplicates
+)
 {
-    if (has_duplicates)
-    {
+    if (has_duplicates) {
         return accumulate_f32_row_scalar_marked(
             a_val,
             b_nnz,
@@ -200,7 +184,8 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
             acc,
             mark,
             touched,
-            touched_count);
+            touched_count
+        );
     }
 
     rvsp_status_t status = mark_f32_row_columns(
@@ -210,10 +195,10 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
         acc,
         mark,
         touched,
-        touched_count);
+        touched_count
+    );
 
-    if (status != RVSP_SUCCESS)
-    {
+    if (status != RVSP_SUCCESS) {
         return status;
     }
 
@@ -222,7 +207,8 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
         b_nnz,
         b_col_idx,
         b_values,
-        acc);
+        acc
+    );
 }
 
 rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
@@ -238,14 +224,14 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
     int32_t **c_row_ptr_out,
     int32_t **c_col_idx_out,
     float **c_values_out,
-    int32_t *c_nnz_out)
+    int32_t *c_nnz_out
+)
 {
     if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
         a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
         b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
         c_row_ptr_out == NULL || c_col_idx_out == NULL ||
-        c_values_out == NULL || c_nnz_out == NULL)
-    {
+        c_values_out == NULL || c_nnz_out == NULL) {
         return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
@@ -260,19 +246,16 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
     uint8_t *mark = NULL;
     uint8_t *b_has_duplicates = NULL;
 
-    if (c_row_ptr == NULL)
-    {
+    if (c_row_ptr == NULL) {
         return RVSP_ERROR_ALLOCATION_FAILED;
     }
 
-    if (b_cols > 0)
-    {
+    if (b_cols > 0) {
         acc = (float *)malloc((size_t)b_cols * sizeof(float));
         touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
         mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
 
-        if (acc == NULL || touched == NULL || mark == NULL)
-        {
+        if (acc == NULL || touched == NULL || mark == NULL) {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -281,12 +264,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
         }
     }
 
-    if (a_cols > 0)
-    {
+    if (a_cols > 0) {
         b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
 
-        if (b_has_duplicates == NULL)
-        {
+        if (b_has_duplicates == NULL) {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -299,10 +280,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
             b_cols,
             b_row_ptr,
             b_col_idx,
-            b_has_duplicates);
+            b_has_duplicates
+        );
 
-        if (status != RVSP_SUCCESS)
-        {
+        if (status != RVSP_SUCCESS) {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -314,13 +295,11 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
 
     int64_t total_nnz = 0;
 
-    for (int32_t row = 0; row < a_rows; row++)
-    {
+    for (int32_t row = 0; row < a_rows; row++) {
         int32_t a_start = a_row_ptr[row];
         int32_t a_end = a_row_ptr[row + 1];
 
-        if (a_start < 0 || a_end < a_start)
-        {
+        if (a_start < 0 || a_end < a_start) {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -331,12 +310,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
 
         int32_t touched_count = 0;
 
-        for (int32_t ap = a_start; ap < a_end; ap++)
-        {
+        for (int32_t ap = a_start; ap < a_end; ap++) {
             int32_t a_col = a_col_idx[ap];
 
-            if (a_col < 0 || a_col >= a_cols)
-            {
+            if (a_col < 0 || a_col >= a_cols) {
                 clear_f32_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(acc);
@@ -349,8 +326,7 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
             int32_t b_start = b_row_ptr[a_col];
             int32_t b_end = b_row_ptr[a_col + 1];
 
-            if (b_start < 0 || b_end < b_start)
-            {
+            if (b_start < 0 || b_end < b_start) {
                 clear_f32_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(acc);
@@ -370,10 +346,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
                 mark,
                 touched,
                 &touched_count,
-                b_has_duplicates ? b_has_duplicates[a_col] : 0);
+                b_has_duplicates ? b_has_duplicates[a_col] : 0
+            );
 
-            if (status != RVSP_SUCCESS)
-            {
+            if (status != RVSP_SUCCESS) {
                 clear_f32_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(acc);
@@ -386,12 +362,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
 
         int32_t row_nnz = 0;
 
-        for (int32_t i = 0; i < touched_count; i++)
-        {
+        for (int32_t i = 0; i < touched_count; i++) {
             int32_t col = touched[i];
 
-            if (acc[col] != 0.0f)
-            {
+            if (acc[col] != 0.0f) {
                 row_nnz++;
             }
         }
@@ -400,8 +374,7 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
 
         total_nnz += row_nnz;
 
-        if (total_nnz > INT32_MAX)
-        {
+        if (total_nnz > INT32_MAX) {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -415,8 +388,7 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
 
     int32_t prefix = 0;
 
-    for (int32_t row = 0; row < a_rows; row++)
-    {
+    for (int32_t row = 0; row < a_rows; row++) {
         int32_t row_count = c_row_ptr[row + 1];
         c_row_ptr[row] = prefix;
         prefix += row_count;
@@ -428,13 +400,11 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
     int32_t *c_col_idx = NULL;
     float *c_values = NULL;
 
-    if (c_nnz > 0)
-    {
+    if (c_nnz > 0) {
         c_col_idx = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
         c_values = (float *)malloc((size_t)c_nnz * sizeof(float));
 
-        if (c_col_idx == NULL || c_values == NULL)
-        {
+        if (c_col_idx == NULL || c_values == NULL) {
             free(c_row_ptr);
             free(c_col_idx);
             free(c_values);
@@ -446,14 +416,12 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
         }
     }
 
-    for (int32_t row = 0; row < a_rows; row++)
-    {
+    for (int32_t row = 0; row < a_rows; row++) {
         int32_t a_start = a_row_ptr[row];
         int32_t a_end = a_row_ptr[row + 1];
         int32_t touched_count = 0;
 
-        for (int32_t ap = a_start; ap < a_end; ap++)
-        {
+        for (int32_t ap = a_start; ap < a_end; ap++) {
             int32_t a_col = a_col_idx[ap];
             int32_t b_start = b_row_ptr[a_col];
             int32_t b_end = b_row_ptr[a_col + 1];
@@ -468,10 +436,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
                 mark,
                 touched,
                 &touched_count,
-                b_has_duplicates ? b_has_duplicates[a_col] : 0);
+                b_has_duplicates ? b_has_duplicates[a_col] : 0
+            );
 
-            if (status != RVSP_SUCCESS)
-            {
+            if (status != RVSP_SUCCESS) {
                 clear_f32_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(c_col_idx);
@@ -488,14 +456,11 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
 
         int32_t out_pos = c_row_ptr[row];
 
-        for (int32_t i = 0; i < touched_count; i++)
-        {
+        for (int32_t i = 0; i < touched_count; i++) {
             int32_t col = touched[i];
 
-            if (acc[col] != 0.0f)
-            {
-                if (out_pos >= c_row_ptr[row + 1])
-                {
+            if (acc[col] != 0.0f) {
+                if (out_pos >= c_row_ptr[row + 1]) {
                     clear_f32_workspace(acc, mark, touched, touched_count);
                     free(c_row_ptr);
                     free(c_col_idx);
@@ -515,8 +480,7 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
 
         clear_f32_workspace(acc, mark, touched, touched_count);
 
-        if (out_pos != c_row_ptr[row + 1])
-        {
+        if (out_pos != c_row_ptr[row + 1]) {
             free(c_row_ptr);
             free(c_col_idx);
             free(c_values);

--- a/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
@@ -1,59 +1,244 @@
 #include <stdint.h>
 #include <stdlib.h>
-#include <stddef.h>
+#include <limits.h>
+
 #include "csr_spgemm_kernels.h"
 
-static int compare_i32_f32(const void *a, const void *b)
+static int compare_i32_rvv_f32(const void *a, const void *b)
 {
     int32_t ia = *(const int32_t *)a;
     int32_t ib = *(const int32_t *)b;
 
     if (ia < ib)
+    {
         return -1;
+    }
+
     if (ia > ib)
+    {
         return 1;
+    }
+
     return 0;
 }
 
-static int reserve_f32_output_capacity_marked(int32_t **col_idx, float **values, int32_t *capacity, int32_t required)
+static void clear_f32_workspace(
+    float *acc,
+    uint8_t *mark,
+    const int32_t *touched,
+    int32_t touched_count)
 {
-    if (required <= *capacity)
+    for (int32_t i = 0; i < touched_count; i++)
     {
-        return 0;
+        int32_t col = touched[i];
+        acc[col] = 0.0f;
+        mark[col] = 0;
     }
-
-    int32_t new_capacity = (*capacity == 0) ? 16 : *capacity;
-
-    while (new_capacity < required)
-    {
-        new_capacity *= 2;
-    }
-
-    int32_t *new_col_idx = (int32_t *)realloc(*col_idx, (size_t)new_capacity * sizeof(int32_t));
-    if (new_col_idx == NULL)
-    {
-        return -1;
-    }
-
-    float *new_values = (float *)realloc(*values, (size_t)new_capacity * sizeof(float));
-    if (new_values == NULL)
-    {
-        return -1;
-    }
-
-    *col_idx = new_col_idx;
-    *values = new_values;
-    *capacity = new_capacity;
-
-    return 0;
 }
 
-rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
-                                                        const int32_t *a_row_ptr, const int32_t *a_col_idx,
-                                                        const float *a_values, const int32_t *b_row_ptr,
-                                                        const int32_t *b_col_idx, const float *b_values,
-                                                        int32_t **c_row_ptr_out, int32_t **c_col_idx_out,
-                                                        float **c_values_out, int32_t *c_nnz_out)
+static rvsp_status_t mark_f32_row_columns(
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    int32_t b_cols,
+    float *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count)
+{
+    for (int32_t p = 0; p < b_nnz; p++)
+    {
+        int32_t col = b_col_idx[p];
+
+        if (col < 0 || col >= b_cols)
+        {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (mark[col] == 0)
+        {
+            mark[col] = 1;
+            touched[*touched_count] = col;
+            (*touched_count)++;
+            acc[col] = 0.0f;
+        }
+    }
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t accumulate_f32_row_scalar_marked(
+    float a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const float *b_values,
+    int32_t b_cols,
+    float *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count)
+{
+    for (int32_t p = 0; p < b_nnz; p++)
+    {
+        int32_t col = b_col_idx[p];
+
+        if (col < 0 || col >= b_cols)
+        {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (mark[col] == 0)
+        {
+            mark[col] = 1;
+            touched[*touched_count] = col;
+            (*touched_count)++;
+            acc[col] = 0.0f;
+        }
+
+        acc[col] += a_val * b_values[p];
+    }
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t build_b_duplicate_flags_f32(
+    int32_t b_rows,
+    int32_t b_cols,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    uint8_t *b_has_duplicates)
+{
+    uint8_t *seen = NULL;
+    int32_t *seen_touched = NULL;
+
+    if (b_cols > 0)
+    {
+        seen = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+        seen_touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+
+        if (seen == NULL || seen_touched == NULL)
+        {
+            free(seen);
+            free(seen_touched);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    for (int32_t row = 0; row < b_rows; row++)
+    {
+        int32_t start = b_row_ptr[row];
+        int32_t end = b_row_ptr[row + 1];
+
+        if (start < 0 || end < start)
+        {
+            free(seen);
+            free(seen_touched);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        int32_t seen_count = 0;
+
+        for (int32_t p = start; p < end; p++)
+        {
+            int32_t col = b_col_idx[p];
+
+            if (col < 0 || col >= b_cols)
+            {
+                for (int32_t i = 0; i < seen_count; i++)
+                {
+                    seen[seen_touched[i]] = 0;
+                }
+
+                free(seen);
+                free(seen_touched);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            if (seen[col] != 0)
+            {
+                b_has_duplicates[row] = 1;
+            }
+            else
+            {
+                seen[col] = 1;
+                seen_touched[seen_count] = col;
+                seen_count++;
+            }
+        }
+
+        for (int32_t i = 0; i < seen_count; i++)
+        {
+            seen[seen_touched[i]] = 0;
+        }
+    }
+
+    free(seen);
+    free(seen_touched);
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
+    float a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const float *b_values,
+    int32_t b_cols,
+    float *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count,
+    uint8_t has_duplicates)
+{
+    if (has_duplicates)
+    {
+        return accumulate_f32_row_scalar_marked(
+            a_val,
+            b_nnz,
+            b_col_idx,
+            b_values,
+            b_cols,
+            acc,
+            mark,
+            touched,
+            touched_count);
+    }
+
+    rvsp_status_t status = mark_f32_row_columns(
+        b_nnz,
+        b_col_idx,
+        b_cols,
+        acc,
+        mark,
+        touched,
+        touched_count);
+
+    if (status != RVSP_SUCCESS)
+    {
+        return status;
+    }
+
+    return rvsp_accumulate_row_f32_rvv_indexed_fast(
+        a_val,
+        b_nnz,
+        b_col_idx,
+        b_values,
+        acc);
+}
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const float *a_values,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    const float *b_values,
+    int32_t **c_row_ptr_out,
+    int32_t **c_col_idx_out,
+    float **c_values_out,
+    int32_t *c_nnz_out)
 {
     if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
         a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
@@ -64,137 +249,294 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t
         return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
+    *c_row_ptr_out = NULL;
+    *c_col_idx_out = NULL;
+    *c_values_out = NULL;
+    *c_nnz_out = 0;
+
     int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
-    float *acc = (float *)calloc((size_t)b_cols, sizeof(float));
-    int32_t *marker = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
-    int32_t *touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+    float *acc = NULL;
+    int32_t *touched = NULL;
+    uint8_t *mark = NULL;
+    uint8_t *b_has_duplicates = NULL;
 
-    if (c_row_ptr == NULL || acc == NULL || marker == NULL || touched == NULL)
+    if (c_row_ptr == NULL)
     {
-        free(c_row_ptr);
-        free(acc);
-        free(marker);
-        free(touched);
-        return RVSP_ERROR_INVALID_ARGUMENT;
+        return RVSP_ERROR_ALLOCATION_FAILED;
     }
 
-    for (int32_t col = 0; col < b_cols; ++col)
+    if (b_cols > 0)
     {
-        marker[col] = -1;
+        acc = (float *)malloc((size_t)b_cols * sizeof(float));
+        touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+        mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+
+        if (acc == NULL || touched == NULL || mark == NULL)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
     }
 
-    int32_t *c_col_idx = NULL;
-    float *c_values = NULL;
-    int32_t capacity = 0;
-    int32_t nnz_count = 0;
-
-    for (int32_t i = 0; i < a_rows; ++i)
+    if (a_cols > 0)
     {
+        b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
+
+        if (b_has_duplicates == NULL)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+
+        rvsp_status_t status = build_b_duplicate_flags_f32(
+            a_cols,
+            b_cols,
+            b_row_ptr,
+            b_col_idx,
+            b_has_duplicates);
+
+        if (status != RVSP_SUCCESS)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return status;
+        }
+    }
+
+    int64_t total_nnz = 0;
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+
+        if (a_start < 0 || a_end < a_start)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
         int32_t touched_count = 0;
 
-        for (int32_t ap = a_row_ptr[i]; ap < a_row_ptr[i + 1]; ++ap)
+        for (int32_t ap = a_start; ap < a_end; ap++)
         {
             int32_t a_col = a_col_idx[ap];
 
             if (a_col < 0 || a_col >= a_cols)
             {
+                clear_f32_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
-                free(c_col_idx);
-                free(c_values);
                 free(acc);
-                free(marker);
                 free(touched);
+                free(mark);
+                free(b_has_duplicates);
                 return RVSP_ERROR_INVALID_ARGUMENT;
             }
 
-            for (int32_t bp = b_row_ptr[a_col]; bp < b_row_ptr[a_col + 1]; ++bp)
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
+
+            if (b_start < 0 || b_end < b_start)
             {
-                int32_t col = b_col_idx[bp];
-
-                if (col < 0 || col >= b_cols)
-                {
-                    free(c_row_ptr);
-                    free(c_col_idx);
-                    free(c_values);
-                    free(acc);
-                    free(marker);
-                    free(touched);
-                    return RVSP_ERROR_INVALID_ARGUMENT;
-                }
-
-                if (marker[col] != i)
-                {
-                    marker[col] = i;
-                    acc[col] = 0.0f;
-                    touched[touched_count++] = col;
-                }
+                clear_f32_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return RVSP_ERROR_INVALID_ARGUMENT;
             }
-        }
 
-        for (int32_t ap = a_row_ptr[i]; ap < a_row_ptr[i + 1]; ++ap)
-        {
-            int32_t a_col = a_col_idx[ap];
-            float a_val = a_values[ap];
-
-            rvsp_status_t status = rvsp_accumulate_row_f32_rvv_indexed_fast(
-                a_val,
-                b_row_ptr[a_col + 1] - b_row_ptr[a_col],
-                &b_col_idx[b_row_ptr[a_col]],
-                &b_values[b_row_ptr[a_col]],
-                acc);
+            rvsp_status_t status = accumulate_f32_row_rvv_or_scalar(
+                a_values[ap],
+                b_end - b_start,
+                &b_col_idx[b_start],
+                &b_values[b_start],
+                b_cols,
+                acc,
+                mark,
+                touched,
+                &touched_count,
+                b_has_duplicates ? b_has_duplicates[a_col] : 0);
 
             if (status != RVSP_SUCCESS)
             {
+                clear_f32_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
-                free(c_col_idx);
-                free(c_values);
                 free(acc);
-                free(marker);
                 free(touched);
+                free(mark);
+                free(b_has_duplicates);
                 return status;
             }
         }
 
-        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_f32);
+        int32_t row_nnz = 0;
 
-        for (int32_t t = 0; t < touched_count; ++t)
+        for (int32_t i = 0; i < touched_count; i++)
         {
-            int32_t col = touched[t];
+            int32_t col = touched[i];
 
             if (acc[col] != 0.0f)
             {
-                if (reserve_f32_output_capacity_marked(
-                        &c_col_idx,
-                        &c_values,
-                        &capacity,
-                        nnz_count + 1) != 0)
+                row_nnz++;
+            }
+        }
+
+        clear_f32_workspace(acc, mark, touched, touched_count);
+
+        total_nnz += row_nnz;
+
+        if (total_nnz > INT32_MAX)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+
+        c_row_ptr[row + 1] = row_nnz;
+    }
+
+    int32_t prefix = 0;
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        int32_t row_count = c_row_ptr[row + 1];
+        c_row_ptr[row] = prefix;
+        prefix += row_count;
+        c_row_ptr[row + 1] = prefix;
+    }
+
+    int32_t c_nnz = (int32_t)total_nnz;
+
+    int32_t *c_col_idx = NULL;
+    float *c_values = NULL;
+
+    if (c_nnz > 0)
+    {
+        c_col_idx = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
+        c_values = (float *)malloc((size_t)c_nnz * sizeof(float));
+
+        if (c_col_idx == NULL || c_values == NULL)
+        {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_start; ap < a_end; ap++)
+        {
+            int32_t a_col = a_col_idx[ap];
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
+
+            rvsp_status_t status = accumulate_f32_row_rvv_or_scalar(
+                a_values[ap],
+                b_end - b_start,
+                &b_col_idx[b_start],
+                &b_values[b_start],
+                b_cols,
+                acc,
+                mark,
+                touched,
+                &touched_count,
+                b_has_duplicates ? b_has_duplicates[a_col] : 0);
+
+            if (status != RVSP_SUCCESS)
+            {
+                clear_f32_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(c_col_idx);
+                free(c_values);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return status;
+            }
+        }
+
+        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_rvv_f32);
+
+        int32_t out_pos = c_row_ptr[row];
+
+        for (int32_t i = 0; i < touched_count; i++)
+        {
+            int32_t col = touched[i];
+
+            if (acc[col] != 0.0f)
+            {
+                if (out_pos >= c_row_ptr[row + 1])
                 {
+                    clear_f32_workspace(acc, mark, touched, touched_count);
                     free(c_row_ptr);
                     free(c_col_idx);
                     free(c_values);
                     free(acc);
-                    free(marker);
                     free(touched);
+                    free(mark);
+                    free(b_has_duplicates);
                     return RVSP_ERROR_INVALID_ARGUMENT;
                 }
 
-                c_col_idx[nnz_count] = col;
-                c_values[nnz_count] = acc[col];
-                nnz_count++;
+                c_col_idx[out_pos] = col;
+                c_values[out_pos] = acc[col];
+                out_pos++;
             }
         }
 
-        c_row_ptr[i + 1] = nnz_count;
+        clear_f32_workspace(acc, mark, touched, touched_count);
+
+        if (out_pos != c_row_ptr[row + 1])
+        {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
     }
 
     free(acc);
-    free(marker);
     free(touched);
+    free(mark);
+    free(b_has_duplicates);
 
     *c_row_ptr_out = c_row_ptr;
     *c_col_idx_out = c_col_idx;
     *c_values_out = c_values;
-    *c_nnz_out = nnz_count;
+    *c_nnz_out = c_nnz;
 
     return RVSP_SUCCESS;
 }

--- a/src/kernels/spgemm/csr_rvv_f64_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f64_indexed_marked.c
@@ -1,0 +1,506 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "csr_spgemm_kernels.h"
+
+static int compare_i32_rvv_f64(const void *a, const void *b)
+{
+    int32_t ia = *(const int32_t *)a;
+    int32_t ib = *(const int32_t *)b;
+
+    if (ia < ib) {
+        return -1;
+    }
+
+    if (ia > ib) {
+        return 1;
+    }
+
+    return 0;
+}
+
+static void clear_f64_workspace(
+    double *acc,
+    uint8_t *mark,
+    const int32_t *touched,
+    int32_t touched_count
+)
+{
+    for (int32_t i = 0; i < touched_count; i++) {
+        int32_t col = touched[i];
+        acc[col] = 0.0;
+        mark[col] = 0;
+    }
+}
+
+static rvsp_status_t mark_f64_row_columns(
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    int32_t b_cols,
+    double *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count
+)
+{
+    for (int32_t p = 0; p < b_nnz; p++) {
+        int32_t col = b_col_idx[p];
+
+        if (col < 0 || col >= b_cols) {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (mark[col] == 0) {
+            mark[col] = 1;
+            touched[*touched_count] = col;
+            (*touched_count)++;
+            acc[col] = 0.0;
+        }
+    }
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t accumulate_f64_row_scalar_marked(
+    double a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const double *b_values,
+    int32_t b_cols,
+    double *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count
+)
+{
+    for (int32_t p = 0; p < b_nnz; p++) {
+        int32_t col = b_col_idx[p];
+
+        if (col < 0 || col >= b_cols) {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (mark[col] == 0) {
+            mark[col] = 1;
+            touched[*touched_count] = col;
+            (*touched_count)++;
+            acc[col] = 0.0;
+        }
+
+        acc[col] += a_val * b_values[p];
+    }
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t build_b_duplicate_flags_f64(
+    int32_t b_rows,
+    int32_t b_cols,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    uint8_t *b_has_duplicates
+)
+{
+    uint8_t *seen = NULL;
+    int32_t *seen_touched = NULL;
+
+    if (b_cols > 0) {
+        seen = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+        seen_touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+
+        if (seen == NULL || seen_touched == NULL) {
+            free(seen);
+            free(seen_touched);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    for (int32_t row = 0; row < b_rows; row++) {
+        int32_t start = b_row_ptr[row];
+        int32_t end = b_row_ptr[row + 1];
+
+        if (start < 0 || end < start) {
+            free(seen);
+            free(seen_touched);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        int32_t seen_count = 0;
+
+        for (int32_t p = start; p < end; p++) {
+            int32_t col = b_col_idx[p];
+
+            if (col < 0 || col >= b_cols) {
+                for (int32_t i = 0; i < seen_count; i++) {
+                    seen[seen_touched[i]] = 0;
+                }
+
+                free(seen);
+                free(seen_touched);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            if (seen[col] != 0) {
+                b_has_duplicates[row] = 1;
+            } else {
+                seen[col] = 1;
+                seen_touched[seen_count] = col;
+                seen_count++;
+            }
+        }
+
+        for (int32_t i = 0; i < seen_count; i++) {
+            seen[seen_touched[i]] = 0;
+        }
+    }
+
+    free(seen);
+    free(seen_touched);
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t accumulate_f64_row_rvv_or_scalar(
+    double a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const double *b_values,
+    int32_t b_cols,
+    double *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count,
+    uint8_t has_duplicates
+)
+{
+    if (has_duplicates) {
+        return accumulate_f64_row_scalar_marked(
+            a_val,
+            b_nnz,
+            b_col_idx,
+            b_values,
+            b_cols,
+            acc,
+            mark,
+            touched,
+            touched_count
+        );
+    }
+
+    rvsp_status_t status = mark_f64_row_columns(
+        b_nnz,
+        b_col_idx,
+        b_cols,
+        acc,
+        mark,
+        touched,
+        touched_count
+    );
+
+    if (status != RVSP_SUCCESS) {
+        return status;
+    }
+
+    return rvsp_accumulate_row_f64_rvv_indexed_fast(
+        a_val,
+        b_nnz,
+        b_col_idx,
+        b_values,
+        acc
+    );
+}
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f64_indexed_marked_raw(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const double *a_values,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    const double *b_values,
+    int32_t **c_row_ptr_out,
+    int32_t **c_col_idx_out,
+    double **c_values_out,
+    int32_t *c_nnz_out
+)
+{
+    if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
+        a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
+        b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
+        c_row_ptr_out == NULL || c_col_idx_out == NULL ||
+        c_values_out == NULL || c_nnz_out == NULL) {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    *c_row_ptr_out = NULL;
+    *c_col_idx_out = NULL;
+    *c_values_out = NULL;
+    *c_nnz_out = 0;
+
+    int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
+    double *acc = NULL;
+    int32_t *touched = NULL;
+    uint8_t *mark = NULL;
+    uint8_t *b_has_duplicates = NULL;
+
+    if (c_row_ptr == NULL) {
+        return RVSP_ERROR_ALLOCATION_FAILED;
+    }
+
+    if (b_cols > 0) {
+        acc = (double *)malloc((size_t)b_cols * sizeof(double));
+        touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+        mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+
+        if (acc == NULL || touched == NULL || mark == NULL) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    if (a_cols > 0) {
+        b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
+
+        if (b_has_duplicates == NULL) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+
+        rvsp_status_t status = build_b_duplicate_flags_f64(
+            a_cols,
+            b_cols,
+            b_row_ptr,
+            b_col_idx,
+            b_has_duplicates
+        );
+
+        if (status != RVSP_SUCCESS) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return status;
+        }
+    }
+
+    int64_t total_nnz = 0;
+
+    for (int32_t row = 0; row < a_rows; row++) {
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+
+        if (a_start < 0 || a_end < a_start) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_start; ap < a_end; ap++) {
+            int32_t a_col = a_col_idx[ap];
+
+            if (a_col < 0 || a_col >= a_cols) {
+                clear_f64_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
+
+            if (b_start < 0 || b_end < b_start) {
+                clear_f64_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            rvsp_status_t status = accumulate_f64_row_rvv_or_scalar(
+                a_values[ap],
+                b_end - b_start,
+                &b_col_idx[b_start],
+                &b_values[b_start],
+                b_cols,
+                acc,
+                mark,
+                touched,
+                &touched_count,
+                b_has_duplicates ? b_has_duplicates[a_col] : 0
+            );
+
+            if (status != RVSP_SUCCESS) {
+                clear_f64_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return status;
+            }
+        }
+
+        int32_t row_nnz = 0;
+
+        for (int32_t i = 0; i < touched_count; i++) {
+            int32_t col = touched[i];
+
+            if (acc[col] != 0.0) {
+                row_nnz++;
+            }
+        }
+
+        clear_f64_workspace(acc, mark, touched, touched_count);
+
+        total_nnz += row_nnz;
+
+        if (total_nnz > INT32_MAX) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+
+        c_row_ptr[row + 1] = row_nnz;
+    }
+
+    int32_t prefix = 0;
+
+    for (int32_t row = 0; row < a_rows; row++) {
+        int32_t row_count = c_row_ptr[row + 1];
+        c_row_ptr[row] = prefix;
+        prefix += row_count;
+        c_row_ptr[row + 1] = prefix;
+    }
+
+    int32_t c_nnz = (int32_t)total_nnz;
+
+    int32_t *c_col_idx = NULL;
+    double *c_values = NULL;
+
+    if (c_nnz > 0) {
+        c_col_idx = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
+        c_values = (double *)malloc((size_t)c_nnz * sizeof(double));
+
+        if (c_col_idx == NULL || c_values == NULL) {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    for (int32_t row = 0; row < a_rows; row++) {
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_start; ap < a_end; ap++) {
+            int32_t a_col = a_col_idx[ap];
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
+
+            rvsp_status_t status = accumulate_f64_row_rvv_or_scalar(
+                a_values[ap],
+                b_end - b_start,
+                &b_col_idx[b_start],
+                &b_values[b_start],
+                b_cols,
+                acc,
+                mark,
+                touched,
+                &touched_count,
+                b_has_duplicates ? b_has_duplicates[a_col] : 0
+            );
+
+            if (status != RVSP_SUCCESS) {
+                clear_f64_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(c_col_idx);
+                free(c_values);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return status;
+            }
+        }
+
+        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_rvv_f64);
+
+        int32_t out_pos = c_row_ptr[row];
+
+        for (int32_t i = 0; i < touched_count; i++) {
+            int32_t col = touched[i];
+
+            if (acc[col] != 0.0) {
+                if (out_pos >= c_row_ptr[row + 1]) {
+                    clear_f64_workspace(acc, mark, touched, touched_count);
+                    free(c_row_ptr);
+                    free(c_col_idx);
+                    free(c_values);
+                    free(acc);
+                    free(touched);
+                    free(mark);
+                    free(b_has_duplicates);
+                    return RVSP_ERROR_INVALID_ARGUMENT;
+                }
+
+                c_col_idx[out_pos] = col;
+                c_values[out_pos] = acc[col];
+                out_pos++;
+            }
+        }
+
+        clear_f64_workspace(acc, mark, touched, touched_count);
+
+        if (out_pos != c_row_ptr[row + 1]) {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+    }
+
+    free(acc);
+    free(touched);
+    free(mark);
+    free(b_has_duplicates);
+
+    *c_row_ptr_out = c_row_ptr;
+    *c_col_idx_out = c_col_idx;
+    *c_values_out = c_values;
+    *c_nnz_out = c_nnz;
+
+    return RVSP_SUCCESS;
+}

--- a/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
@@ -1,258 +1,506 @@
-/*
- * Copyright (C) 2026 rv-sparse contributors
- *
- * SPDX-License-Identifier: GPL-3.0-only
- *
- * Experimental optimized CSR SpGEMM RVV INT8 raw kernel.
- *
- * Computes INT8 x INT8 with INT32 accumulation/output.
- *
- * Optimization strategy:
- * - Reuse one dense accumulator across rows.
- * - Track touched columns using marker/touched arrays.
- * - Avoid scanning all B columns when constructing each output row.
- * - Use RVV indexed gather/scatter for row accumulation.
- */
-
 #include <stdint.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "csr_spgemm_kernels.h"
 
-static int compare_i32(const void *a, const void *b)
+static int compare_i32_rvv_i8(const void *a, const void *b)
 {
-    int32_t x = *(const int32_t *)a;
-    int32_t y = *(const int32_t *)b;
+    int32_t ia = *(const int32_t *)a;
+    int32_t ib = *(const int32_t *)b;
 
-    return (x > y) - (x < y);
+    if (ia < ib) {
+        return -1;
+    }
+
+    if (ia > ib) {
+        return 1;
+    }
+
+    return 0;
 }
 
-static rvsp_status_t reserve_output_capacity(int32_t **col_idx, int32_t **values,
-                                             int32_t *capacity,
-                                             int32_t required)
+static void clear_i8_workspace(
+    int32_t *acc,
+    uint8_t *mark,
+    const int32_t *touched,
+    int32_t touched_count
+)
 {
-    if (required <= *capacity)
-    {
-        return RVSP_SUCCESS;
+    for (int32_t i = 0; i < touched_count; i++) {
+        int32_t col = touched[i];
+        acc[col] = 0;
+        mark[col] = 0;
     }
+}
 
-    int32_t new_capacity = *capacity > 0 ? *capacity : 64;
+static rvsp_status_t mark_i8_row_columns(
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    int32_t b_cols,
+    int32_t *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count
+)
+{
+    for (int32_t p = 0; p < b_nnz; p++) {
+        int32_t col = b_col_idx[p];
 
-    while (new_capacity < required)
-    {
-        if (new_capacity > INT32_MAX / 2)
-        {
-            return RVSP_ERROR_ALLOCATION_FAILED;
+        if (col < 0 || col >= b_cols) {
+            return RVSP_ERROR_INVALID_ARGUMENT;
         }
 
-        new_capacity *= 2;
+        if (mark[col] == 0) {
+            mark[col] = 1;
+            touched[*touched_count] = col;
+            (*touched_count)++;
+            acc[col] = 0;
+        }
     }
-
-    int32_t *new_col_idx = (int32_t *)realloc(
-        *col_idx,
-        (size_t)new_capacity * sizeof(int32_t));
-
-    if (!new_col_idx)
-    {
-        return RVSP_ERROR_ALLOCATION_FAILED;
-    }
-
-    int32_t *new_values = (int32_t *)realloc(
-        *values,
-        (size_t)new_capacity * sizeof(int32_t));
-
-    if (!new_values)
-    {
-        return RVSP_ERROR_ALLOCATION_FAILED;
-    }
-
-    *col_idx = new_col_idx;
-    *values = new_values;
-    *capacity = new_capacity;
 
     return RVSP_SUCCESS;
 }
 
-rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
-                                                       const int32_t *a_row_ptr, const int32_t *a_col_idx,
-                                                       const int8_t *a_values, const int32_t *b_row_ptr,
-                                                       const int32_t *b_col_idx, const int8_t *b_values,
-                                                       int32_t **c_row_ptr_out, int32_t **c_col_idx_out,
-                                                       int32_t **c_values_out, int32_t *c_nnz_out)
+static rvsp_status_t accumulate_i8_row_scalar_marked(
+    int8_t a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const int8_t *b_values,
+    int32_t b_cols,
+    int32_t *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count
+)
 {
-    if (!a_row_ptr || !a_col_idx || !a_values ||
-        !b_row_ptr || !b_col_idx || !b_values ||
-        !c_row_ptr_out || !c_col_idx_out ||
-        !c_values_out || !c_nnz_out)
-    {
-        return RVSP_ERROR_NULL_POINTER;
+    for (int32_t p = 0; p < b_nnz; p++) {
+        int32_t col = b_col_idx[p];
+
+        if (col < 0 || col >= b_cols) {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (mark[col] == 0) {
+            mark[col] = 1;
+            touched[*touched_count] = col;
+            (*touched_count)++;
+            acc[col] = 0;
+        }
+
+        acc[col] += (int32_t)a_val * (int32_t)b_values[p];
     }
 
-    if (a_rows <= 0 || a_cols <= 0 || b_cols <= 0)
-    {
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t build_b_duplicate_flags_i8(
+    int32_t b_rows,
+    int32_t b_cols,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    uint8_t *b_has_duplicates
+)
+{
+    uint8_t *seen = NULL;
+    int32_t *seen_touched = NULL;
+
+    if (b_cols > 0) {
+        seen = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+        seen_touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+
+        if (seen == NULL || seen_touched == NULL) {
+            free(seen);
+            free(seen_touched);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    for (int32_t row = 0; row < b_rows; row++) {
+        int32_t start = b_row_ptr[row];
+        int32_t end = b_row_ptr[row + 1];
+
+        if (start < 0 || end < start) {
+            free(seen);
+            free(seen_touched);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        int32_t seen_count = 0;
+
+        for (int32_t p = start; p < end; p++) {
+            int32_t col = b_col_idx[p];
+
+            if (col < 0 || col >= b_cols) {
+                for (int32_t i = 0; i < seen_count; i++) {
+                    seen[seen_touched[i]] = 0;
+                }
+
+                free(seen);
+                free(seen_touched);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            if (seen[col] != 0) {
+                b_has_duplicates[row] = 1;
+            } else {
+                seen[col] = 1;
+                seen_touched[seen_count] = col;
+                seen_count++;
+            }
+        }
+
+        for (int32_t i = 0; i < seen_count; i++) {
+            seen[seen_touched[i]] = 0;
+        }
+    }
+
+    free(seen);
+    free(seen_touched);
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t accumulate_i8_row_rvv_or_scalar(
+    int8_t a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const int8_t *b_values,
+    int32_t b_cols,
+    int32_t *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count,
+    uint8_t has_duplicates
+)
+{
+    if (has_duplicates) {
+        return accumulate_i8_row_scalar_marked(
+            a_val,
+            b_nnz,
+            b_col_idx,
+            b_values,
+            b_cols,
+            acc,
+            mark,
+            touched,
+            touched_count
+        );
+    }
+
+    rvsp_status_t status = mark_i8_row_columns(
+        b_nnz,
+        b_col_idx,
+        b_cols,
+        acc,
+        mark,
+        touched,
+        touched_count
+    );
+
+    if (status != RVSP_SUCCESS) {
+        return status;
+    }
+
+    return rvsp_accumulate_row_i8_rvv_indexed_fast(
+        a_val,
+        b_nnz,
+        b_col_idx,
+        b_values,
+        acc
+    );
+}
+
+rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const int8_t *a_values,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    const int8_t *b_values,
+    int32_t **c_row_ptr_out,
+    int32_t **c_col_idx_out,
+    int32_t **c_values_out,
+    int32_t *c_nnz_out
+)
+{
+    if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
+        a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
+        b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
+        c_row_ptr_out == NULL || c_col_idx_out == NULL ||
+        c_values_out == NULL || c_nnz_out == NULL) {
         return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
+    *c_row_ptr_out = NULL;
+    *c_col_idx_out = NULL;
+    *c_values_out = NULL;
+    *c_nnz_out = 0;
+
     int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
+    int32_t *acc = NULL;
+    int32_t *touched = NULL;
+    uint8_t *mark = NULL;
+    uint8_t *b_has_duplicates = NULL;
 
-    int32_t output_capacity = 64;
-    int32_t *c_col_idx = (int32_t *)malloc((size_t)output_capacity * sizeof(int32_t));
-    int32_t *c_values = (int32_t *)malloc((size_t)output_capacity * sizeof(int32_t));
-
-    int32_t *acc = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
-    int32_t *marker = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
-    int32_t *touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
-
-    if (!c_row_ptr || !c_col_idx || !c_values || !acc || !marker || !touched)
-    {
-        free(c_row_ptr);
-        free(c_col_idx);
-        free(c_values);
-        free(acc);
-        free(marker);
-        free(touched);
+    if (c_row_ptr == NULL) {
         return RVSP_ERROR_ALLOCATION_FAILED;
     }
 
-    for (int32_t col = 0; col < b_cols; col++)
-    {
-        marker[col] = -1;
-        acc[col] = 0;
+    if (b_cols > 0) {
+        acc = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+        touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+        mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+
+        if (acc == NULL || touched == NULL || mark == NULL) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
     }
 
-    int32_t nnz_count = 0;
+    if (a_cols > 0) {
+        b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
 
-    for (int32_t row = 0; row < a_rows; row++)
-    {
-        c_row_ptr[row] = nnz_count;
+        if (b_has_duplicates == NULL) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
 
-        int32_t touched_count = 0;
+        rvsp_status_t status = build_b_duplicate_flags_i8(
+            a_cols,
+            b_cols,
+            b_row_ptr,
+            b_col_idx,
+            b_has_duplicates
+        );
 
+        if (status != RVSP_SUCCESS) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return status;
+        }
+    }
+
+    int64_t total_nnz = 0;
+
+    for (int32_t row = 0; row < a_rows; row++) {
         int32_t a_start = a_row_ptr[row];
         int32_t a_end = a_row_ptr[row + 1];
 
-        for (int32_t a_pos = a_start; a_pos < a_end; a_pos++)
-        {
-            int32_t k = a_col_idx[a_pos];
+        if (a_start < 0 || a_end < a_start) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
 
-            if (k < 0 || k >= a_cols)
-            {
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_start; ap < a_end; ap++) {
+            int32_t a_col = a_col_idx[ap];
+
+            if (a_col < 0 || a_col >= a_cols) {
+                clear_i8_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
-                free(c_col_idx);
-                free(c_values);
                 free(acc);
-                free(marker);
                 free(touched);
-                return RVSP_ERROR_INVALID_CSR;
+                free(mark);
+                free(b_has_duplicates);
+                return RVSP_ERROR_INVALID_ARGUMENT;
             }
 
-            int32_t b_start = b_row_ptr[k];
-            int32_t b_end = b_row_ptr[k + 1];
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
 
-            /*
-             * Prepass:
-             * - validate columns
-             * - register touched columns
-             * - initialize accumulator entries for the current row
-             */
-            for (int32_t b_pos = b_start; b_pos < b_end; b_pos++)
-            {
-                int32_t col = b_col_idx[b_pos];
-
-                if (col < 0 || col >= b_cols)
-                {
-                    free(c_row_ptr);
-                    free(c_col_idx);
-                    free(c_values);
-                    free(acc);
-                    free(marker);
-                    free(touched);
-                    return RVSP_ERROR_INVALID_CSR;
-                }
-
-                if (marker[col] != row)
-                {
-                    marker[col] = row;
-                    touched[touched_count] = col;
-                    touched_count++;
-                    acc[col] = 0;
-                }
+            if (b_start < 0 || b_end < b_start) {
+                clear_i8_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return RVSP_ERROR_INVALID_ARGUMENT;
             }
 
-            rvsp_status_t status = rvsp_accumulate_row_i8_rvv_indexed_fast(a_values[a_pos], b_end - b_start,
-                                                                          &b_col_idx[b_start], &b_values[b_start],
-                                                                          acc);
+            rvsp_status_t status = accumulate_i8_row_rvv_or_scalar(
+                a_values[ap],
+                b_end - b_start,
+                &b_col_idx[b_start],
+                &b_values[b_start],
+                b_cols,
+                acc,
+                mark,
+                touched,
+                &touched_count,
+                b_has_duplicates ? b_has_duplicates[a_col] : 0
+            );
 
-            if (status != RVSP_SUCCESS)
-            {
+            if (status != RVSP_SUCCESS) {
+                clear_i8_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
-                free(c_col_idx);
-                free(c_values);
                 free(acc);
-                free(marker);
                 free(touched);
+                free(mark);
+                free(b_has_duplicates);
                 return status;
             }
         }
 
-        // Keep output deterministic and comparable with the scalar reference.
-        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32);
+        int32_t row_nnz = 0;
 
-        rvsp_status_t status = reserve_output_capacity(&c_col_idx, &c_values,
-                                                       &output_capacity, nnz_count + touched_count);
+        for (int32_t i = 0; i < touched_count; i++) {
+            int32_t col = touched[i];
 
-        if (status != RVSP_SUCCESS)
-        {
+            if (acc[col] != 0) {
+                row_nnz++;
+            }
+        }
+
+        clear_i8_workspace(acc, mark, touched, touched_count);
+
+        total_nnz += row_nnz;
+
+        if (total_nnz > INT32_MAX) {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+
+        c_row_ptr[row + 1] = row_nnz;
+    }
+
+    int32_t prefix = 0;
+
+    for (int32_t row = 0; row < a_rows; row++) {
+        int32_t row_count = c_row_ptr[row + 1];
+        c_row_ptr[row] = prefix;
+        prefix += row_count;
+        c_row_ptr[row + 1] = prefix;
+    }
+
+    int32_t c_nnz = (int32_t)total_nnz;
+
+    int32_t *c_col_idx = NULL;
+    int32_t *c_values = NULL;
+
+    if (c_nnz > 0) {
+        c_col_idx = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
+        c_values = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
+
+        if (c_col_idx == NULL || c_values == NULL) {
             free(c_row_ptr);
             free(c_col_idx);
             free(c_values);
             free(acc);
-            free(marker);
             free(touched);
-            return status;
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_ALLOCATION_FAILED;
         }
+    }
 
-        for (int32_t i = 0; i < touched_count; i++)
-        {
-            int32_t col = touched[i];
+    for (int32_t row = 0; row < a_rows; row++) {
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+        int32_t touched_count = 0;
 
-            if (acc[col] != 0)
-            {
-                c_col_idx[nnz_count] = col;
-                c_values[nnz_count] = acc[col];
-                nnz_count++;
+        for (int32_t ap = a_start; ap < a_end; ap++) {
+            int32_t a_col = a_col_idx[ap];
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
+
+            rvsp_status_t status = accumulate_i8_row_rvv_or_scalar(
+                a_values[ap],
+                b_end - b_start,
+                &b_col_idx[b_start],
+                &b_values[b_start],
+                b_cols,
+                acc,
+                mark,
+                touched,
+                &touched_count,
+                b_has_duplicates ? b_has_duplicates[a_col] : 0
+            );
+
+            if (status != RVSP_SUCCESS) {
+                clear_i8_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(c_col_idx);
+                free(c_values);
+                free(acc);
+                free(touched);
+                free(mark);
+                free(b_has_duplicates);
+                return status;
             }
         }
-    }
 
-    c_row_ptr[a_rows] = nnz_count;
+        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_rvv_i8);
 
-    int32_t *final_col_idx = (int32_t *)realloc(
-        c_col_idx,
-        (size_t)nnz_count * sizeof(int32_t));
+        int32_t out_pos = c_row_ptr[row];
 
-    if (final_col_idx)
-    {
-        c_col_idx = final_col_idx;
-    }
+        for (int32_t i = 0; i < touched_count; i++) {
+            int32_t col = touched[i];
 
-    int32_t *final_values = (int32_t *)realloc(
-        c_values,
-        (size_t)nnz_count * sizeof(int32_t));
+            if (acc[col] != 0) {
+                if (out_pos >= c_row_ptr[row + 1]) {
+                    clear_i8_workspace(acc, mark, touched, touched_count);
+                    free(c_row_ptr);
+                    free(c_col_idx);
+                    free(c_values);
+                    free(acc);
+                    free(touched);
+                    free(mark);
+                    free(b_has_duplicates);
+                    return RVSP_ERROR_INVALID_ARGUMENT;
+                }
 
-    if (final_values)
-    {
-        c_values = final_values;
+                c_col_idx[out_pos] = col;
+                c_values[out_pos] = acc[col];
+                out_pos++;
+            }
+        }
+
+        clear_i8_workspace(acc, mark, touched, touched_count);
+
+        if (out_pos != c_row_ptr[row + 1]) {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(touched);
+            free(mark);
+            free(b_has_duplicates);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
     }
 
     free(acc);
-    free(marker);
     free(touched);
+    free(mark);
+    free(b_has_duplicates);
 
     *c_row_ptr_out = c_row_ptr;
     *c_col_idx_out = c_col_idx;
     *c_values_out = c_values;
-    *c_nnz_out = nnz_count;
+    *c_nnz_out = c_nnz;
 
     return RVSP_SUCCESS;
 }

--- a/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_i8_indexed_marked.c
@@ -9,11 +9,13 @@ static int compare_i32_rvv_i8(const void *a, const void *b)
     int32_t ia = *(const int32_t *)a;
     int32_t ib = *(const int32_t *)b;
 
-    if (ia < ib) {
+    if (ia < ib)
+    {
         return -1;
     }
 
-    if (ia > ib) {
+    if (ia > ib)
+    {
         return 1;
     }
 
@@ -24,10 +26,10 @@ static void clear_i8_workspace(
     int32_t *acc,
     uint8_t *mark,
     const int32_t *touched,
-    int32_t touched_count
-)
+    int32_t touched_count)
 {
-    for (int32_t i = 0; i < touched_count; i++) {
+    for (int32_t i = 0; i < touched_count; i++)
+    {
         int32_t col = touched[i];
         acc[col] = 0;
         mark[col] = 0;
@@ -41,17 +43,19 @@ static rvsp_status_t mark_i8_row_columns(
     int32_t *acc,
     uint8_t *mark,
     int32_t *touched,
-    int32_t *touched_count
-)
+    int32_t *touched_count)
 {
-    for (int32_t p = 0; p < b_nnz; p++) {
+    for (int32_t p = 0; p < b_nnz; p++)
+    {
         int32_t col = b_col_idx[p];
 
-        if (col < 0 || col >= b_cols) {
+        if (col < 0 || col >= b_cols)
+        {
             return RVSP_ERROR_INVALID_ARGUMENT;
         }
 
-        if (mark[col] == 0) {
+        if (mark[col] == 0)
+        {
             mark[col] = 1;
             touched[*touched_count] = col;
             (*touched_count)++;
@@ -71,17 +75,19 @@ static rvsp_status_t accumulate_i8_row_scalar_marked(
     int32_t *acc,
     uint8_t *mark,
     int32_t *touched,
-    int32_t *touched_count
-)
+    int32_t *touched_count)
 {
-    for (int32_t p = 0; p < b_nnz; p++) {
+    for (int32_t p = 0; p < b_nnz; p++)
+    {
         int32_t col = b_col_idx[p];
 
-        if (col < 0 || col >= b_cols) {
+        if (col < 0 || col >= b_cols)
+        {
             return RVSP_ERROR_INVALID_ARGUMENT;
         }
 
-        if (mark[col] == 0) {
+        if (mark[col] == 0)
+        {
             mark[col] = 1;
             touched[*touched_count] = col;
             (*touched_count)++;
@@ -99,28 +105,31 @@ static rvsp_status_t build_b_duplicate_flags_i8(
     int32_t b_cols,
     const int32_t *b_row_ptr,
     const int32_t *b_col_idx,
-    uint8_t *b_has_duplicates
-)
+    uint8_t *b_has_duplicates)
 {
     uint8_t *seen = NULL;
     int32_t *seen_touched = NULL;
 
-    if (b_cols > 0) {
+    if (b_cols > 0)
+    {
         seen = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
         seen_touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
 
-        if (seen == NULL || seen_touched == NULL) {
+        if (seen == NULL || seen_touched == NULL)
+        {
             free(seen);
             free(seen_touched);
             return RVSP_ERROR_ALLOCATION_FAILED;
         }
     }
 
-    for (int32_t row = 0; row < b_rows; row++) {
+    for (int32_t row = 0; row < b_rows; row++)
+    {
         int32_t start = b_row_ptr[row];
         int32_t end = b_row_ptr[row + 1];
 
-        if (start < 0 || end < start) {
+        if (start < 0 || end < start)
+        {
             free(seen);
             free(seen_touched);
             return RVSP_ERROR_INVALID_ARGUMENT;
@@ -128,11 +137,14 @@ static rvsp_status_t build_b_duplicate_flags_i8(
 
         int32_t seen_count = 0;
 
-        for (int32_t p = start; p < end; p++) {
+        for (int32_t p = start; p < end; p++)
+        {
             int32_t col = b_col_idx[p];
 
-            if (col < 0 || col >= b_cols) {
-                for (int32_t i = 0; i < seen_count; i++) {
+            if (col < 0 || col >= b_cols)
+            {
+                for (int32_t i = 0; i < seen_count; i++)
+                {
                     seen[seen_touched[i]] = 0;
                 }
 
@@ -141,16 +153,20 @@ static rvsp_status_t build_b_duplicate_flags_i8(
                 return RVSP_ERROR_INVALID_ARGUMENT;
             }
 
-            if (seen[col] != 0) {
+            if (seen[col] != 0)
+            {
                 b_has_duplicates[row] = 1;
-            } else {
+            }
+            else
+            {
                 seen[col] = 1;
                 seen_touched[seen_count] = col;
                 seen_count++;
             }
         }
 
-        for (int32_t i = 0; i < seen_count; i++) {
+        for (int32_t i = 0; i < seen_count; i++)
+        {
             seen[seen_touched[i]] = 0;
         }
     }
@@ -171,10 +187,10 @@ static rvsp_status_t accumulate_i8_row_rvv_or_scalar(
     uint8_t *mark,
     int32_t *touched,
     int32_t *touched_count,
-    uint8_t has_duplicates
-)
+    uint8_t has_duplicates)
 {
-    if (has_duplicates) {
+    if (has_duplicates)
+    {
         return accumulate_i8_row_scalar_marked(
             a_val,
             b_nnz,
@@ -184,8 +200,7 @@ static rvsp_status_t accumulate_i8_row_rvv_or_scalar(
             acc,
             mark,
             touched,
-            touched_count
-        );
+            touched_count);
     }
 
     rvsp_status_t status = mark_i8_row_columns(
@@ -195,10 +210,10 @@ static rvsp_status_t accumulate_i8_row_rvv_or_scalar(
         acc,
         mark,
         touched,
-        touched_count
-    );
+        touched_count);
 
-    if (status != RVSP_SUCCESS) {
+    if (status != RVSP_SUCCESS)
+    {
         return status;
     }
 
@@ -207,8 +222,7 @@ static rvsp_status_t accumulate_i8_row_rvv_or_scalar(
         b_nnz,
         b_col_idx,
         b_values,
-        acc
-    );
+        acc);
 }
 
 rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
@@ -224,14 +238,14 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
     int32_t **c_row_ptr_out,
     int32_t **c_col_idx_out,
     int32_t **c_values_out,
-    int32_t *c_nnz_out
-)
+    int32_t *c_nnz_out)
 {
     if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
         a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
         b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
         c_row_ptr_out == NULL || c_col_idx_out == NULL ||
-        c_values_out == NULL || c_nnz_out == NULL) {
+        c_values_out == NULL || c_nnz_out == NULL)
+    {
         return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
@@ -246,16 +260,19 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
     uint8_t *mark = NULL;
     uint8_t *b_has_duplicates = NULL;
 
-    if (c_row_ptr == NULL) {
+    if (c_row_ptr == NULL)
+    {
         return RVSP_ERROR_ALLOCATION_FAILED;
     }
 
-    if (b_cols > 0) {
+    if (b_cols > 0)
+    {
         acc = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
         touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
         mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
 
-        if (acc == NULL || touched == NULL || mark == NULL) {
+        if (acc == NULL || touched == NULL || mark == NULL)
+        {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -264,10 +281,12 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
         }
     }
 
-    if (a_cols > 0) {
+    if (a_cols > 0)
+    {
         b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
 
-        if (b_has_duplicates == NULL) {
+        if (b_has_duplicates == NULL)
+        {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -280,10 +299,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
             b_cols,
             b_row_ptr,
             b_col_idx,
-            b_has_duplicates
-        );
+            b_has_duplicates);
 
-        if (status != RVSP_SUCCESS) {
+        if (status != RVSP_SUCCESS)
+        {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -295,11 +314,13 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
 
     int64_t total_nnz = 0;
 
-    for (int32_t row = 0; row < a_rows; row++) {
+    for (int32_t row = 0; row < a_rows; row++)
+    {
         int32_t a_start = a_row_ptr[row];
         int32_t a_end = a_row_ptr[row + 1];
 
-        if (a_start < 0 || a_end < a_start) {
+        if (a_start < 0 || a_end < a_start)
+        {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -310,10 +331,12 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
 
         int32_t touched_count = 0;
 
-        for (int32_t ap = a_start; ap < a_end; ap++) {
+        for (int32_t ap = a_start; ap < a_end; ap++)
+        {
             int32_t a_col = a_col_idx[ap];
 
-            if (a_col < 0 || a_col >= a_cols) {
+            if (a_col < 0 || a_col >= a_cols)
+            {
                 clear_i8_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(acc);
@@ -326,7 +349,8 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
             int32_t b_start = b_row_ptr[a_col];
             int32_t b_end = b_row_ptr[a_col + 1];
 
-            if (b_start < 0 || b_end < b_start) {
+            if (b_start < 0 || b_end < b_start)
+            {
                 clear_i8_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(acc);
@@ -346,10 +370,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
                 mark,
                 touched,
                 &touched_count,
-                b_has_duplicates ? b_has_duplicates[a_col] : 0
-            );
+                b_has_duplicates ? b_has_duplicates[a_col] : 0);
 
-            if (status != RVSP_SUCCESS) {
+            if (status != RVSP_SUCCESS)
+            {
                 clear_i8_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(acc);
@@ -362,10 +386,12 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
 
         int32_t row_nnz = 0;
 
-        for (int32_t i = 0; i < touched_count; i++) {
+        for (int32_t i = 0; i < touched_count; i++)
+        {
             int32_t col = touched[i];
 
-            if (acc[col] != 0) {
+            if (acc[col] != 0)
+            {
                 row_nnz++;
             }
         }
@@ -374,7 +400,8 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
 
         total_nnz += row_nnz;
 
-        if (total_nnz > INT32_MAX) {
+        if (total_nnz > INT32_MAX)
+        {
             free(c_row_ptr);
             free(acc);
             free(touched);
@@ -388,7 +415,8 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
 
     int32_t prefix = 0;
 
-    for (int32_t row = 0; row < a_rows; row++) {
+    for (int32_t row = 0; row < a_rows; row++)
+    {
         int32_t row_count = c_row_ptr[row + 1];
         c_row_ptr[row] = prefix;
         prefix += row_count;
@@ -400,11 +428,13 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
     int32_t *c_col_idx = NULL;
     int32_t *c_values = NULL;
 
-    if (c_nnz > 0) {
+    if (c_nnz > 0)
+    {
         c_col_idx = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
         c_values = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
 
-        if (c_col_idx == NULL || c_values == NULL) {
+        if (c_col_idx == NULL || c_values == NULL)
+        {
             free(c_row_ptr);
             free(c_col_idx);
             free(c_values);
@@ -416,12 +446,14 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
         }
     }
 
-    for (int32_t row = 0; row < a_rows; row++) {
+    for (int32_t row = 0; row < a_rows; row++)
+    {
         int32_t a_start = a_row_ptr[row];
         int32_t a_end = a_row_ptr[row + 1];
         int32_t touched_count = 0;
 
-        for (int32_t ap = a_start; ap < a_end; ap++) {
+        for (int32_t ap = a_start; ap < a_end; ap++)
+        {
             int32_t a_col = a_col_idx[ap];
             int32_t b_start = b_row_ptr[a_col];
             int32_t b_end = b_row_ptr[a_col + 1];
@@ -436,10 +468,10 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
                 mark,
                 touched,
                 &touched_count,
-                b_has_duplicates ? b_has_duplicates[a_col] : 0
-            );
+                b_has_duplicates ? b_has_duplicates[a_col] : 0);
 
-            if (status != RVSP_SUCCESS) {
+            if (status != RVSP_SUCCESS)
+            {
                 clear_i8_workspace(acc, mark, touched, touched_count);
                 free(c_row_ptr);
                 free(c_col_idx);
@@ -456,11 +488,14 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
 
         int32_t out_pos = c_row_ptr[row];
 
-        for (int32_t i = 0; i < touched_count; i++) {
+        for (int32_t i = 0; i < touched_count; i++)
+        {
             int32_t col = touched[i];
 
-            if (acc[col] != 0) {
-                if (out_pos >= c_row_ptr[row + 1]) {
+            if (acc[col] != 0)
+            {
+                if (out_pos >= c_row_ptr[row + 1])
+                {
                     clear_i8_workspace(acc, mark, touched, touched_count);
                     free(c_row_ptr);
                     free(c_col_idx);
@@ -480,7 +515,8 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
 
         clear_i8_workspace(acc, mark, touched, touched_count);
 
-        if (out_pos != c_row_ptr[row + 1]) {
+        if (out_pos != c_row_ptr[row + 1])
+        {
             free(c_row_ptr);
             free(c_col_idx);
             free(c_values);

--- a/src/kernels/spgemm/csr_scalar_f64.c
+++ b/src/kernels/spgemm/csr_scalar_f64.c
@@ -1,0 +1,300 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "csr_spgemm_kernels.h"
+
+static int compare_i32_f64(const void *a, const void *b)
+{
+    int32_t ia = *(const int32_t *)a;
+    int32_t ib = *(const int32_t *)b;
+
+    if (ia < ib)
+    {
+        return -1;
+    }
+
+    if (ia > ib)
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+static void reset_f64_workspace(
+    double *acc,
+    uint8_t *mark,
+    const int32_t *touched,
+    int32_t touched_count)
+{
+    for (int32_t i = 0; i < touched_count; i++)
+    {
+        int32_t col = touched[i];
+        acc[col] = 0.0;
+        mark[col] = 0;
+    }
+}
+
+rvsp_status_t rvsp_spgemm_csr_scalar_f64_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
+                                             const int32_t *a_row_ptr, const int32_t *a_col_idx,
+                                             const double *a_values, const int32_t *b_row_ptr,
+                                             const int32_t *b_col_idx, const double *b_values,
+                                             int32_t **c_row_ptr_out, int32_t **c_col_idx_out,
+                                             double **c_values_out, int32_t *c_nnz_out)
+{
+    if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
+        a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
+        b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
+        c_row_ptr_out == NULL || c_col_idx_out == NULL ||
+        c_values_out == NULL || c_nnz_out == NULL)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    *c_row_ptr_out = NULL;
+    *c_col_idx_out = NULL;
+    *c_values_out = NULL;
+    *c_nnz_out = 0;
+
+    int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
+    double *acc = NULL;
+    int32_t *touched = NULL;
+    uint8_t *mark = NULL;
+
+    if (c_row_ptr == NULL)
+    {
+        return RVSP_ERROR_ALLOCATION_FAILED;
+    }
+
+    if (b_cols > 0)
+    {
+        acc = (double *)malloc((size_t)b_cols * sizeof(double));
+        touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+        mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+
+        if (acc == NULL || touched == NULL || mark == NULL)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    int64_t total_nnz = 0;
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+
+        if (a_start < 0 || a_end < a_start)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_start; ap < a_end; ap++)
+        {
+            int32_t a_col = a_col_idx[ap];
+
+            if (a_col < 0 || a_col >= a_cols)
+            {
+                reset_f64_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(acc);
+                free(touched);
+                free(mark);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
+
+            if (b_start < 0 || b_end < b_start)
+            {
+                reset_f64_workspace(acc, mark, touched, touched_count);
+                free(c_row_ptr);
+                free(acc);
+                free(touched);
+                free(mark);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            double a_val = a_values[ap];
+
+            for (int32_t bp = b_start; bp < b_end; bp++)
+            {
+                int32_t col = b_col_idx[bp];
+
+                if (col < 0 || col >= b_cols)
+                {
+                    reset_f64_workspace(acc, mark, touched, touched_count);
+                    free(c_row_ptr);
+                    free(acc);
+                    free(touched);
+                    free(mark);
+                    return RVSP_ERROR_INVALID_ARGUMENT;
+                }
+
+                if (mark[col] == 0)
+                {
+                    mark[col] = 1;
+                    touched[touched_count] = col;
+                    touched_count++;
+                    acc[col] = 0.0;
+                }
+
+                acc[col] += a_val * b_values[bp];
+            }
+        }
+
+        int32_t row_nnz = 0;
+
+        for (int32_t i = 0; i < touched_count; i++)
+        {
+            int32_t col = touched[i];
+
+            if (acc[col] != 0.0)
+            {
+                row_nnz++;
+            }
+        }
+
+        reset_f64_workspace(acc, mark, touched, touched_count);
+
+        total_nnz += row_nnz;
+
+        if (total_nnz > INT32_MAX)
+        {
+            free(c_row_ptr);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+
+        c_row_ptr[row + 1] = row_nnz;
+    }
+
+    int32_t prefix = 0;
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        int32_t row_count = c_row_ptr[row + 1];
+        c_row_ptr[row] = prefix;
+        prefix += row_count;
+        c_row_ptr[row + 1] = prefix;
+    }
+
+    int32_t c_nnz = (int32_t)total_nnz;
+
+    int32_t *c_col_idx = NULL;
+    double *c_values = NULL;
+
+    if (c_nnz > 0)
+    {
+        c_col_idx = (int32_t *)malloc((size_t)c_nnz * sizeof(int32_t));
+        c_values = (double *)malloc((size_t)c_nnz * sizeof(double));
+
+        if (c_col_idx == NULL || c_values == NULL)
+        {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        int32_t a_start = a_row_ptr[row];
+        int32_t a_end = a_row_ptr[row + 1];
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_start; ap < a_end; ap++)
+        {
+            int32_t a_col = a_col_idx[ap];
+            int32_t b_start = b_row_ptr[a_col];
+            int32_t b_end = b_row_ptr[a_col + 1];
+            double a_val = a_values[ap];
+
+            for (int32_t bp = b_start; bp < b_end; bp++)
+            {
+                int32_t col = b_col_idx[bp];
+
+                if (mark[col] == 0)
+                {
+                    mark[col] = 1;
+                    touched[touched_count] = col;
+                    touched_count++;
+                    acc[col] = 0.0;
+                }
+
+                acc[col] += a_val * b_values[bp];
+            }
+        }
+
+        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_f64);
+
+        int32_t out_pos = c_row_ptr[row];
+
+        for (int32_t i = 0; i < touched_count; i++)
+        {
+            int32_t col = touched[i];
+
+            if (acc[col] != 0.0)
+            {
+                if (out_pos >= c_row_ptr[row + 1])
+                {
+                    reset_f64_workspace(acc, mark, touched, touched_count);
+                    free(c_row_ptr);
+                    free(c_col_idx);
+                    free(c_values);
+                    free(acc);
+                    free(touched);
+                    free(mark);
+                    return RVSP_ERROR_INVALID_ARGUMENT;
+                }
+
+                c_col_idx[out_pos] = col;
+                c_values[out_pos] = acc[col];
+                out_pos++;
+            }
+        }
+
+        reset_f64_workspace(acc, mark, touched, touched_count);
+
+        if (out_pos != c_row_ptr[row + 1])
+        {
+            free(c_row_ptr);
+            free(c_col_idx);
+            free(c_values);
+            free(acc);
+            free(touched);
+            free(mark);
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+    }
+
+    free(acc);
+    free(touched);
+    free(mark);
+
+    *c_row_ptr_out = c_row_ptr;
+    *c_col_idx_out = c_col_idx;
+    *c_values_out = c_values;
+    *c_nnz_out = c_nnz;
+
+    return RVSP_SUCCESS;
+}

--- a/src/kernels/spgemm/csr_spgemm_kernels.h
+++ b/src/kernels/spgemm/csr_spgemm_kernels.h
@@ -42,6 +42,36 @@ rvsp_status_t rvsp_spgemm_csr_scalar_unroll4_f32(
     const rvsp_csr_matrix_t *B,
     rvsp_csr_matrix_t *C);
 
+// RVV.
+rvsp_status_t rvsp_accumulate_row_i8_rvv_indexed_fast(
+    int8_t a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const int8_t *b_values,
+    int32_t *acc);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C);
+
+rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(
+    float a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const float *b_values,
+    float *acc);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f64_indexed_marked(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C);
+
 /*
  * Raw kernel layer:
  * Uses plain pointers and dimensions.
@@ -92,14 +122,6 @@ rvsp_status_t rvsp_spgemm_csr_scalar_unroll4_f32_raw(
     float **c_values_out,
     int32_t *c_nnz_out);
 
-// This is the layer we optimize and port to RISC-V/RVV.
-rvsp_status_t rvsp_accumulate_row_i8_rvv_indexed_fast(
-    int8_t a_val,
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    const int8_t *b_values,
-    int32_t *acc);
-
 rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
     int32_t a_rows,
     int32_t a_cols,
@@ -114,18 +136,6 @@ rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked_raw(
     int32_t **c_col_idx_out,
     int32_t **c_values_out,
     int32_t *c_nnz_out);
-
-rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked(
-    const rvsp_csr_matrix_t *A,
-    const rvsp_csr_matrix_t *B,
-    rvsp_csr_matrix_t *C);
-
-rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(
-    float a_val,
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    const float *b_values,
-    float *acc);
 
 rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
     int32_t a_rows,
@@ -142,9 +152,42 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
     float **c_values_out,
     int32_t *c_nnz_out);
 
-rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked(
-    const rvsp_csr_matrix_t *A,
-    const rvsp_csr_matrix_t *B,
-    rvsp_csr_matrix_t *C);
+// fp64
+rvsp_status_t rvsp_spgemm_csr_scalar_f64_raw(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const double *a_values,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    const double *b_values,
+    int32_t **c_row_ptr_out,
+    int32_t **c_col_idx_out,
+    double **c_values_out,
+    int32_t *c_nnz_out);
+
+rvsp_status_t rvsp_accumulate_row_f64_rvv_indexed_fast(
+    double a_val,
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    const double *b_values,
+    double *acc);
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f64_indexed_marked_raw(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const double *a_values,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    const double *b_values,
+    int32_t **c_row_ptr_out,
+    int32_t **c_col_idx_out,
+    double **c_values_out,
+    int32_t *c_nnz_out);
 
 #endif /*RVSP_CSR_SPGEMM_KERNELS_H*/

--- a/src/kernels/spgemm/csr_spgemm_kernels.h
+++ b/src/kernels/spgemm/csr_spgemm_kernels.h
@@ -31,6 +31,11 @@ rvsp_status_t rvsp_spgemm_csr_scalar_f32(
     const rvsp_csr_matrix_t *B,
     rvsp_csr_matrix_t *C);
 
+rvsp_status_t rvsp_spgemm_csr_scalar_f64(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C);
+
 // Optimizations : unroll, fused , vectorized, etc ....
 rvsp_status_t rvsp_spgemm_csr_scalar_unroll4_f32(
     const rvsp_csr_matrix_t *A,

--- a/src/kernels/spgemm/csr_spgemm_wrappers.c
+++ b/src/kernels/spgemm/csr_spgemm_wrappers.c
@@ -233,10 +233,9 @@ rvsp_status_t rvsp_spgemm_csr_scalar_unroll4_f32(const rvsp_csr_matrix_t *A, con
 }
 
 // wrapper for i8_indexed
-rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked(
-    const rvsp_csr_matrix_t *A,
-    const rvsp_csr_matrix_t *B,
-    rvsp_csr_matrix_t *C)
+rvsp_status_t rvsp_spgemm_csr_rvv_i8_indexed_marked(const rvsp_csr_matrix_t *A,
+                                                    const rvsp_csr_matrix_t *B,
+                                                    rvsp_csr_matrix_t *C)
 {
     if (A == NULL || B == NULL || C == NULL)
     {
@@ -341,6 +340,119 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked(const rvsp_csr_matrix_t *A,
     C->col_idx = c_col_idx;
     C->values = c_values;
     C->dtype = RVSP_DTYPE_FP32;
+
+    return RVSP_SUCCESS;
+}
+
+// fp64
+rvsp_status_t rvsp_spgemm_csr_scalar_f64(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C)
+{
+    if (A == NULL || B == NULL || C == NULL)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->dtype != RVSP_DTYPE_FP64 || B->dtype != RVSP_DTYPE_FP64)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->cols != B->rows)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    int32_t *c_row_ptr = NULL;
+    int32_t *c_col_idx = NULL;
+    double *c_values = NULL;
+    int32_t c_nnz = 0;
+
+    rvsp_status_t status = rvsp_spgemm_csr_scalar_f64_raw(
+        A->rows,
+        A->cols,
+        B->cols,
+        A->row_ptr,
+        A->col_idx,
+        (const double *)A->values,
+        B->row_ptr,
+        B->col_idx,
+        (const double *)B->values,
+        &c_row_ptr,
+        &c_col_idx,
+        &c_values,
+        &c_nnz);
+
+    if (status != RVSP_SUCCESS)
+    {
+        return status;
+    }
+
+    C->rows = A->rows;
+    C->cols = B->cols;
+    C->nnz = c_nnz;
+    C->row_ptr = c_row_ptr;
+    C->col_idx = c_col_idx;
+    C->values = c_values;
+    C->dtype = RVSP_DTYPE_FP64;
+
+    return RVSP_SUCCESS;
+}
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f64_indexed_marked(
+    const rvsp_csr_matrix_t *A,
+    const rvsp_csr_matrix_t *B,
+    rvsp_csr_matrix_t *C)
+{
+    if (A == NULL || B == NULL || C == NULL)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->dtype != RVSP_DTYPE_FP64 || B->dtype != RVSP_DTYPE_FP64)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (A->cols != B->rows)
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    int32_t *c_row_ptr = NULL;
+    int32_t *c_col_idx = NULL;
+    double *c_values = NULL;
+    int32_t c_nnz = 0;
+
+    rvsp_status_t status = rvsp_spgemm_csr_rvv_f64_indexed_marked_raw(
+        A->rows,
+        A->cols,
+        B->cols,
+        A->row_ptr,
+        A->col_idx,
+        (const double *)A->values,
+        B->row_ptr,
+        B->col_idx,
+        (const double *)B->values,
+        &c_row_ptr,
+        &c_col_idx,
+        &c_values,
+        &c_nnz);
+
+    if (status != RVSP_SUCCESS)
+    {
+        return status;
+    }
+
+    C->rows = A->rows;
+    C->cols = B->cols;
+    C->nnz = c_nnz;
+    C->row_ptr = c_row_ptr;
+    C->col_idx = c_col_idx;
+    C->values = c_values;
+    C->dtype = RVSP_DTYPE_FP64;
 
     return RVSP_SUCCESS;
 }


### PR DESCRIPTION
This PR adds FP64 CSR SpGEMM support and improves the RVV CSR SpGEMM backends.

## Changes

- Adds FP64 scalar CSR SpGEMM backend.
- Adds FP64 RVV CSR SpGEMM backend.
- Adds RVV FP64 row accumulation helper.
- Updates RVV INT8 and FP32 backends to use two-pass output preallocation.
- Connects FP64 scalar and RVV paths through the dispatcher and wrappers.

## Notes

The scalar INT8/FP32 dense-output fixes were merged separately. This PR builds on top of that work and focuses on FP64 and RVV backend improvements.

## Testing

```bash
make clean
make test TARGET_ARCH=riscv
```

```bash
test_spgemm_csr_f32: PASS
test_spgemm_csr_unroll4_f32: PASS
test_spgemm_csr_i8: PASS
--- All Tests Passed ---
```