### PR TITLE
Perf/f32 rvv accum policy framework

### DIFF
--- a/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
@@ -5,45 +5,170 @@
 
 #if defined(__riscv_vector)
 #include <riscv_vector.h>
-#define EXP_HAVE_RVV_INTRINSICS 1
+#define RVSP_HAVE_RVV_INTRINSICS 1
 #endif
 
-rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz,
-                                                      const int32_t *b_col_idx,
-                                                      const float *b_values,
-                                                      float *acc)
+#if defined(__GNUC__) || defined(__clang__)
+#define RVSP_LIKELY(x) __builtin_expect(!!(x), 1)
+#define RVSP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define RVSP_LIKELY(x) (x)
+#define RVSP_UNLIKELY(x) (x)
+#endif
+
+/*
+ * Try:
+ *   -DRVSP_RVV_F32_MIN_B_NNZ=64
+ *   -DRVSP_RVV_F32_MIN_B_NNZ=128
+ */
+#ifndef RVSP_RVV_F32_MIN_B_NNZ
+#define RVSP_RVV_F32_MIN_B_NNZ 128
+#endif
+
+#ifndef RVSP_RVV_F32_CONTIG_MIN
+#define RVSP_RVV_F32_CONTIG_MIN 8
+#endif
+
+static inline void rvsp_accumulate_row_f32_scalar_unroll4(float a_val, int32_t b_nnz, const int32_t *b_col_idx, const float *b_values, float *acc)
 {
-    if (b_nnz < 0 || b_col_idx == NULL || b_values == NULL || acc == NULL)
+    int32_t p = 0;
+
+    for (; p + 3 < b_nnz; p += 4)
+    {
+        const int32_t c0 = b_col_idx[p + 0];
+        const int32_t c1 = b_col_idx[p + 1];
+        const int32_t c2 = b_col_idx[p + 2];
+        const int32_t c3 = b_col_idx[p + 3];
+
+        acc[c0] += a_val * b_values[p + 0];
+        acc[c1] += a_val * b_values[p + 1];
+        acc[c2] += a_val * b_values[p + 2];
+        acc[c3] += a_val * b_values[p + 3];
+    }
+
+    for (; p < b_nnz; p++)
+    {
+        const int32_t col = b_col_idx[p];
+        acc[col] += a_val * b_values[p];
+    }
+}
+
+static inline int32_t rvsp_consecutive_run_i32(
+    const int32_t *idx,
+    int32_t n)
+{
+    if (RVSP_UNLIKELY(n <= 0))
+    {
+        return 0;
+    }
+
+    const int32_t base = idx[0];
+    int32_t run = 1;
+
+    while (run < n && idx[run] == base + run)
+    {
+        run++;
+    }
+
+    return run;
+}
+
+rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz, const int32_t *b_col_idx, const float *b_values, float *acc)
+{
+    if (RVSP_UNLIKELY(b_nnz < 0 ||
+                      b_col_idx == NULL ||
+                      b_values == NULL ||
+                      acc == NULL))
     {
         return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
-#if defined(EXP_HAVE_RVV_INTRINSICS)
+    if (b_nnz == 0)
+    {
+        return RVSP_SUCCESS;
+    }
+    if (b_nnz < RVSP_RVV_F32_MIN_B_NNZ)
+    {
+        rvsp_accumulate_row_f32_scalar_unroll4(
+            a_val,
+            b_nnz,
+            b_col_idx,
+            b_values,
+            acc);
+        return RVSP_SUCCESS;
+    }
+
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
     int32_t p = 0;
 
     while (p < b_nnz)
     {
-        size_t vl = __riscv_vsetvl_e32m4((size_t)(b_nnz - p));
+        const int32_t remaining = b_nnz - p;
+        const int32_t run =
+            rvsp_consecutive_run_i32(&b_col_idx[p], remaining);
 
-        vfloat32m4_t vb = __riscv_vle32_v_f32m4(&b_values[p], vl);
-        vfloat32m4_t vprod = __riscv_vfmul_vf_f32m4(vb, a_val, vl);
+        if (run >= RVSP_RVV_F32_CONTIG_MIN)
+        {
+            const int32_t base_col = b_col_idx[p];
+            int32_t q = 0;
 
-        vint32m4_t vidx_i32 = __riscv_vle32_v_i32m4(&b_col_idx[p], vl);
-        vint32m4_t voff_i32 = __riscv_vsll_vx_i32m4(vidx_i32, 2, vl);
-        vuint32m4_t voff_u32 = __riscv_vreinterpret_v_i32m4_u32m4(voff_i32);
+            while (q < run)
+            {
+                const size_t vl =
+                    __riscv_vsetvl_e32m4((size_t)(run - q));
 
-        vfloat32m4_t vacc = __riscv_vluxei32_v_f32m4(acc, voff_u32, vl);
-        vacc = __riscv_vfadd_vv_f32m4(vacc, vprod, vl);
-        __riscv_vsuxei32_v_f32m4(acc, voff_u32, vacc, vl);
+                const vfloat32m4_t vb =
+                    __riscv_vle32_v_f32m4(&b_values[p + q], vl);
 
-        p += (int32_t)vl;
+                vfloat32m4_t vacc =
+                    __riscv_vle32_v_f32m4(&acc[base_col + q], vl);
+
+                vacc = __riscv_vfmacc_vf_f32m4(vacc, a_val, vb, vl);
+
+                __riscv_vse32_v_f32m4(&acc[base_col + q], vacc, vl);
+
+                q += (int32_t)vl;
+            }
+
+            p += run;
+            continue;
+        }
+
+        // Jump to inefiecient
+
+        {
+            const size_t vl =
+                __riscv_vsetvl_e32m2((size_t)remaining);
+
+            const vfloat32m2_t vb =
+                __riscv_vle32_v_f32m2(&b_values[p], vl);
+
+            const vint32m2_t vidx_i32 =
+                __riscv_vle32_v_i32m2(&b_col_idx[p], vl);
+
+            const vint32m2_t voff_i32 =
+                __riscv_vsll_vx_i32m2(vidx_i32, 2, vl);
+
+            const vuint32m2_t voff_u32 =
+                __riscv_vreinterpret_v_i32m2_u32m2(voff_i32);
+
+            vfloat32m2_t vacc =
+                __riscv_vluxei32_v_f32m2(acc, voff_u32, vl);
+
+            vacc = __riscv_vfmacc_vf_f32m2(vacc, a_val, vb, vl);
+
+            __riscv_vsuxei32_v_f32m2(acc, voff_u32, vacc, vl);
+
+            p += (int32_t)vl;
+        }
     }
 #else
-    for (int32_t p = 0; p < b_nnz; ++p)
-    {
-        int32_t col = b_col_idx[p];
-        acc[col] += a_val * b_values[p];
-    }
+    rvsp_accumulate_row_f32_scalar_unroll4(
+        a_val,
+        b_nnz,
+        b_col_idx,
+        b_values,
+        acc);
 #endif
 
     return RVSP_SUCCESS;

--- a/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
@@ -120,23 +120,152 @@ static inline int32_t rvsp_consecutive_run_i32(
     return run;
 }
 
-rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz, const int32_t *b_col_idx, const float *b_values, float *acc)
+static inline int32_t rvsp_find_next_contig_run_bounded_i32(
+    const int32_t *RVSP_RESTRICT idx,
+    int32_t n,
+    int32_t min_run,
+    int32_t scan_limit,
+    int32_t *RVSP_RESTRICT run_out)
 {
-    if (RVSP_UNLIKELY(b_nnz < 0 || b_col_idx == NULL || b_values == NULL || acc == NULL))
+    if (RVSP_UNLIKELY(run_out == NULL))
     {
-        return RVSP_ERROR_INVALID_ARGUMENT;
+        return 0;
     }
 
-    if (b_nnz == 0)
+    *run_out = 0;
+
+    if (RVSP_UNLIKELY(idx == NULL || n <= 0))
     {
-        return RVSP_SUCCESS;
-    }
-    if (b_nnz < RVSP_RVV_F32_MIN_B_NNZ)
-    {
-        rvsp_accumulate_row_f32_scalar_unroll4(a_val, b_nnz, b_col_idx, b_values, acc);
-        return RVSP_SUCCESS;
+        return 0;
     }
 
+    if (min_run <= 1)
+    {
+        *run_out = rvsp_consecutive_run_i32(idx, n);
+        return 0;
+    }
+
+    if (scan_limit <= 0)
+    {
+        scan_limit = n;
+    }
+
+    const int32_t limit = rvsp_min_i32(n, scan_limit);
+
+    if (limit < min_run)
+    {
+        return limit;
+    }
+
+    for (int32_t i = 0; i + min_run <= limit; i++)
+    {
+        if (idx[i + 1] != idx[i] + 1)
+        {
+            continue;
+        }
+
+        int32_t run = 2;
+
+        while (i + run < n && idx[i + run] == idx[i] + run)
+        {
+            run++;
+        }
+
+        if (run >= min_run)
+        {
+            *run_out = run;
+            return i;
+        }
+
+        i += run - 1;
+    }
+
+    return limit;
+}
+
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+static inline void rvsp_accumulate_row_f32_rvv_contig_chunk(
+    float a_val,
+    int32_t n,
+    int32_t base_col,
+    const float *RVSP_RESTRICT b_values,
+    float *RVSP_RESTRICT acc)
+{
+    int32_t q = 0;
+
+    while (q < n)
+    {
+        const size_t vl =
+            __riscv_vsetvl_e32m4((size_t)(n - q));
+
+        const vfloat32m4_t vb =
+            __riscv_vle32_v_f32m4(&b_values[q], vl);
+
+        vfloat32m4_t vacc =
+            __riscv_vle32_v_f32m4(&acc[base_col + q], vl);
+
+        vacc =
+            __riscv_vfmacc_vf_f32m4(vacc, a_val, vb, vl);
+
+        __riscv_vse32_v_f32m4(
+            &acc[base_col + q],
+            vacc,
+            vl);
+
+        q += (int32_t)vl;
+    }
+}
+
+static inline void rvsp_accumulate_row_f32_rvv_indexed_chunk(
+    float a_val,
+    int32_t n,
+    const int32_t *RVSP_RESTRICT b_col_idx,
+    const float *RVSP_RESTRICT b_values,
+    float *RVSP_RESTRICT acc)
+{
+    int32_t q = 0;
+
+    while (q < n)
+    {
+        const size_t vl =
+            __riscv_vsetvl_e32m2((size_t)(n - q));
+
+        const vfloat32m2_t vb =
+            __riscv_vle32_v_f32m2(&b_values[q], vl);
+
+        const vint32m2_t vidx_i32 =
+            __riscv_vle32_v_i32m2(&b_col_idx[q], vl);
+
+        const vint32m2_t voff_i32 =
+            __riscv_vsll_vx_i32m2(vidx_i32, 2, vl);
+
+        const vuint32m2_t voff_u32 =
+            __riscv_vreinterpret_v_i32m2_u32m2(voff_i32);
+
+        vfloat32m2_t vacc =
+            __riscv_vluxei32_v_f32m2(acc, voff_u32, vl);
+
+        vacc =
+            __riscv_vfmacc_vf_f32m2(vacc, a_val, vb, vl);
+
+        __riscv_vsuxei32_v_f32m2(
+            acc,
+            voff_u32,
+            vacc,
+            vl);
+
+        q += (int32_t)vl;
+    }
+}
+#endif
+
+static inline void rvsp_accumulate_row_f32_policy0_baseline(
+    float a_val,
+    int32_t b_nnz,
+    const int32_t *RVSP_RESTRICT b_col_idx,
+    const float *RVSP_RESTRICT b_values,
+    float *RVSP_RESTRICT acc)
+{
 #if defined(RVSP_HAVE_RVV_INTRINSICS)
     int32_t p = 0;
 
@@ -148,26 +277,12 @@ rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nn
 
         if (run >= RVSP_RVV_F32_CONTIG_MIN)
         {
-            const int32_t base_col = b_col_idx[p];
-            int32_t q = 0;
-
-            while (q < run)
-            {
-                const size_t vl =
-                    __riscv_vsetvl_e32m4((size_t)(run - q));
-
-                const vfloat32m4_t vb =
-                    __riscv_vle32_v_f32m4(&b_values[p + q], vl);
-
-                vfloat32m4_t vacc =
-                    __riscv_vle32_v_f32m4(&acc[base_col + q], vl);
-
-                vacc = __riscv_vfmacc_vf_f32m4(vacc, a_val, vb, vl);
-
-                __riscv_vse32_v_f32m4(&acc[base_col + q], vacc, vl);
-
-                q += (int32_t)vl;
-            }
+            rvsp_accumulate_row_f32_rvv_contig_chunk(
+                a_val,
+                run,
+                b_col_idx[p],
+                &b_values[p],
+                acc);
 
             p += run;
             continue;
@@ -192,7 +307,8 @@ rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nn
             vfloat32m2_t vacc =
                 __riscv_vluxei32_v_f32m2(acc, voff_u32, vl);
 
-            vacc = __riscv_vfmacc_vf_f32m2(vacc, a_val, vb, vl);
+            vacc =
+                __riscv_vfmacc_vf_f32m2(vacc, a_val, vb, vl);
 
             __riscv_vsuxei32_v_f32m2(acc, voff_u32, vacc, vl);
 

--- a/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2026 rv-sparse contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ */
+
 #include <stdint.h>
 #include <stddef.h>
 
@@ -24,9 +31,52 @@
 #define RVSP_RVV_F32_CONTIG_MIN 8
 #endif
 
-static inline void rvsp_accumulate_row_f32_scalar_unroll4(float a_val, int32_t b_nnz, const int32_t *b_col_idx, const float *b_values, float *acc)
+#ifndef RVSP_RVV_F32_ACCUM_POLICY
+#define RVSP_RVV_F32_ACCUM_POLICY 0
+#endif
+
+#ifndef RVSP_RVV_F32_INDEXED_MIN
+#define RVSP_RVV_F32_INDEXED_MIN 2048
+#endif
+
+#ifndef RVSP_RVV_F32_SCAN_AHEAD_MAX
+#define RVSP_RVV_F32_SCAN_AHEAD_MAX 256
+#endif
+
+static inline int32_t rvsp_min_i32(int32_t a, int32_t b)
+{
+    return a < b ? a : b;
+}
+
+static inline void rvsp_accumulate_row_f32_scalar_unroll8(
+    float a_val,
+    int32_t b_nnz,
+    const int32_t *RVSP_RESTRICT b_col_idx,
+    const float *RVSP_RESTRICT b_values,
+    float *RVSP_RESTRICT acc)
 {
     int32_t p = 0;
+
+    for (; p + 7 < b_nnz; p += 8)
+    {
+        const int32_t c0 = b_col_idx[p + 0];
+        const int32_t c1 = b_col_idx[p + 1];
+        const int32_t c2 = b_col_idx[p + 2];
+        const int32_t c3 = b_col_idx[p + 3];
+        const int32_t c4 = b_col_idx[p + 4];
+        const int32_t c5 = b_col_idx[p + 5];
+        const int32_t c6 = b_col_idx[p + 6];
+        const int32_t c7 = b_col_idx[p + 7];
+
+        acc[c0] += a_val * b_values[p + 0];
+        acc[c1] += a_val * b_values[p + 1];
+        acc[c2] += a_val * b_values[p + 2];
+        acc[c3] += a_val * b_values[p + 3];
+        acc[c4] += a_val * b_values[p + 4];
+        acc[c5] += a_val * b_values[p + 5];
+        acc[c6] += a_val * b_values[p + 6];
+        acc[c7] += a_val * b_values[p + 7];
+    }
 
     for (; p + 3 < b_nnz; p += 4)
     {
@@ -146,7 +196,135 @@ rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nn
         }
     }
 #else
-    rvsp_accumulate_row_f32_scalar_unroll4(a_val, b_nnz, b_col_idx, b_values, acc);
+    rvsp_accumulate_row_f32_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values, acc);
+#endif
+}
+
+static inline void rvsp_accumulate_row_f32_policy1_contig_only(float a_val, int32_t b_nnz, const int32_t *RVSP_RESTRICT b_col_idx,
+                                                               const float *RVSP_RESTRICT b_values, float *RVSP_RESTRICT acc)
+{
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+    int32_t p = 0;
+
+    while (p < b_nnz)
+    {
+        const int32_t remaining = b_nnz - p;
+
+        int32_t run = 0;
+        const int32_t offset =
+            rvsp_find_next_contig_run_bounded_i32(&b_col_idx[p], remaining, RVSP_RVV_F32_CONTIG_MIN, RVSP_RVV_F32_SCAN_AHEAD_MAX, &run);
+
+        if (offset > 0)
+        {
+            rvsp_accumulate_row_f32_scalar_unroll8(a_val, offset, &b_col_idx[p], &b_values[p], acc);
+
+            p += offset;
+            continue;
+        }
+
+        if (run >= RVSP_RVV_F32_CONTIG_MIN)
+        {
+            rvsp_accumulate_row_f32_rvv_contig_chunk(a_val, run, b_col_idx[p], &b_values[p], acc);
+
+            p += run;
+            continue;
+        }
+
+        rvsp_accumulate_row_f32_scalar_unroll8(a_val, remaining, &b_col_idx[p], &b_values[p], acc);
+
+        p += remaining;
+    }
+#else
+    rvsp_accumulate_row_f32_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values, acc);
+#endif
+}
+
+static inline void rvsp_accumulate_row_f32_policy2_indexed_threshold(
+    float a_val,
+    int32_t b_nnz,
+    const int32_t *RVSP_RESTRICT b_col_idx,
+    const float *RVSP_RESTRICT b_values,
+    float *RVSP_RESTRICT acc)
+{
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+    int32_t p = 0;
+
+    while (p < b_nnz)
+    {
+        const int32_t remaining = b_nnz - p;
+
+        int32_t run = 0;
+        const int32_t offset =
+            rvsp_find_next_contig_run_bounded_i32(&b_col_idx[p], remaining, RVSP_RVV_F32_CONTIG_MIN, RVSP_RVV_F32_SCAN_AHEAD_MAX, &run);
+
+        if (offset > 0)
+        {
+            rvsp_accumulate_row_f32_scalar_unroll8(a_val, offset, &b_col_idx[p], &b_values[p], acc);
+
+            p += offset;
+            continue;
+        }
+
+        if (run >= RVSP_RVV_F32_CONTIG_MIN)
+        {
+            rvsp_accumulate_row_f32_rvv_contig_chunk(a_val, run, b_col_idx[p], &b_values[p], acc);
+
+            p += run;
+            continue;
+        }
+
+        if (remaining >= RVSP_RVV_F32_INDEXED_MIN)
+        {
+            rvsp_accumulate_row_f32_rvv_indexed_chunk(a_val, remaining, &b_col_idx[p], &b_values[p], acc);
+        }
+        else
+        {
+            rvsp_accumulate_row_f32_scalar_unroll8(a_val, remaining, &b_col_idx[p], &b_values[p], acc);
+        }
+
+        p += remaining;
+    }
+#else
+    rvsp_accumulate_row_f32_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values, acc);
+#endif
+}
+
+rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz, const int32_t *b_col_idx,
+                                                       const float *b_values, float *acc)
+{
+    if (RVSP_UNLIKELY(b_nnz < 0 ||
+                      b_col_idx == NULL ||
+                      b_values == NULL ||
+                      acc == NULL))
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (b_nnz == 0)
+    {
+        return RVSP_SUCCESS;
+    }
+
+    if (a_val == 0.0f)
+    {
+        return RVSP_SUCCESS;
+    }
+
+    if (b_nnz < RVSP_RVV_F32_MIN_B_NNZ)
+    {
+        rvsp_accumulate_row_f32_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values, acc);
+
+        return RVSP_SUCCESS;
+    }
+
+#if RVSP_RVV_F32_ACCUM_POLICY == 0
+    rvsp_accumulate_row_f32_policy0_baseline(a_val, b_nnz, b_col_idx, b_values, acc);
+#elif RVSP_RVV_F32_ACCUM_POLICY == 1
+    rvsp_accumulate_row_f32_policy1_contig_only(a_val, b_nnz, b_col_idx, b_values, acc);
+#elif RVSP_RVV_F32_ACCUM_POLICY == 2
+    rvsp_accumulate_row_f32_policy2_indexed_threshold(a_val, b_nnz, b_col_idx, b_values, acc);
+#else
+#error "Unsupported RVSP_RVV_F32_ACCUM_POLICY. Use 0, 1, or 2."
 #endif
 
     return RVSP_SUCCESS;

--- a/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
@@ -16,13 +16,8 @@
 #define RVSP_UNLIKELY(x) (x)
 #endif
 
-/*
- * Try:
- *   -DRVSP_RVV_F32_MIN_B_NNZ=64
- *   -DRVSP_RVV_F32_MIN_B_NNZ=128
- */
 #ifndef RVSP_RVV_F32_MIN_B_NNZ
-#define RVSP_RVV_F32_MIN_B_NNZ 128
+#define RVSP_RVV_F32_MIN_B_NNZ 512
 #endif
 
 #ifndef RVSP_RVV_F32_CONTIG_MIN
@@ -53,9 +48,7 @@ static inline void rvsp_accumulate_row_f32_scalar_unroll4(float a_val, int32_t b
     }
 }
 
-static inline int32_t rvsp_consecutive_run_i32(
-    const int32_t *idx,
-    int32_t n)
+static inline int32_t rvsp_consecutive_run_i32(const int32_t *idx, int32_t n)
 {
     if (RVSP_UNLIKELY(n <= 0))
     {
@@ -75,10 +68,7 @@ static inline int32_t rvsp_consecutive_run_i32(
 
 rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nnz, const int32_t *b_col_idx, const float *b_values, float *acc)
 {
-    if (RVSP_UNLIKELY(b_nnz < 0 ||
-                      b_col_idx == NULL ||
-                      b_values == NULL ||
-                      acc == NULL))
+    if (RVSP_UNLIKELY(b_nnz < 0 || b_col_idx == NULL || b_values == NULL || acc == NULL))
     {
         return RVSP_ERROR_INVALID_ARGUMENT;
     }
@@ -89,12 +79,7 @@ rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nn
     }
     if (b_nnz < RVSP_RVV_F32_MIN_B_NNZ)
     {
-        rvsp_accumulate_row_f32_scalar_unroll4(
-            a_val,
-            b_nnz,
-            b_col_idx,
-            b_values,
-            acc);
+        rvsp_accumulate_row_f32_scalar_unroll4(a_val, b_nnz, b_col_idx, b_values, acc);
         return RVSP_SUCCESS;
     }
 
@@ -134,8 +119,6 @@ rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nn
             continue;
         }
 
-        // Jump to inefiecient
-
         {
             const size_t vl =
                 __riscv_vsetvl_e32m2((size_t)remaining);
@@ -163,12 +146,7 @@ rvsp_status_t rvsp_accumulate_row_f32_rvv_indexed_fast(float a_val, int32_t b_nn
         }
     }
 #else
-    rvsp_accumulate_row_f32_scalar_unroll4(
-        a_val,
-        b_nnz,
-        b_col_idx,
-        b_values,
-        acc);
+    rvsp_accumulate_row_f32_scalar_unroll4(a_val, b_nnz, b_col_idx, b_values, acc);
 #endif
 
     return RVSP_SUCCESS;

--- a/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f32_rvv_indexed_fast.c
@@ -18,9 +18,11 @@
 #if defined(__GNUC__) || defined(__clang__)
 #define RVSP_LIKELY(x) __builtin_expect(!!(x), 1)
 #define RVSP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#define RVSP_RESTRICT __restrict__
 #else
 #define RVSP_LIKELY(x) (x)
 #define RVSP_UNLIKELY(x) (x)
+#define RVSP_RESTRICT
 #endif
 
 #ifndef RVSP_RVV_F32_MIN_B_NNZ
@@ -98,9 +100,11 @@ static inline void rvsp_accumulate_row_f32_scalar_unroll8(
     }
 }
 
-static inline int32_t rvsp_consecutive_run_i32(const int32_t *idx, int32_t n)
+static inline int32_t rvsp_consecutive_run_i32(
+    const int32_t *RVSP_RESTRICT idx,
+    int32_t n)
 {
-    if (RVSP_UNLIKELY(n <= 0))
+    if (RVSP_UNLIKELY(idx == NULL || n <= 0))
     {
         return 0;
     }

--- a/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
@@ -4,33 +4,101 @@
 
 #include "csr_spgemm_kernels.h"
 
+#if defined(__GNUC__) || defined(__clang__)
+#define RVSP_LIKELY(x) __builtin_expect(!!(x), 1)
+#define RVSP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define RVSP_LIKELY(x) (x)
+#define RVSP_UNLIKELY(x) (x)
+#endif
+
+#ifndef RVSP_RVV_F32_MIN_B_NNZ
+#define RVSP_RVV_F32_MIN_B_NNZ 128
+#endif
+
+#ifndef RVSP_SORT_INSERTION_LIMIT
+#define RVSP_SORT_INSERTION_LIMIT 32
+#endif
+
 static int compare_i32_rvv_f32(const void *a, const void *b)
 {
-    int32_t ia = *(const int32_t *)a;
-    int32_t ib = *(const int32_t *)b;
+    const int32_t ia = *(const int32_t *)a;
+    const int32_t ib = *(const int32_t *)b;
 
-    if (ia < ib) {
+    if (ia < ib)
+    {
         return -1;
     }
 
-    if (ia > ib) {
+    if (ia > ib)
+    {
         return 1;
     }
 
     return 0;
 }
 
+static void insertion_sort_i32_rvv_f32(int32_t *x, int32_t n)
+{
+    for (int32_t i = 1; i < n; i++)
+    {
+        const int32_t key = x[i];
+        int32_t j = i - 1;
+
+        while (j >= 0 && x[j] > key)
+        {
+            x[j + 1] = x[j];
+            j--;
+        }
+
+        x[j + 1] = key;
+    }
+}
+
+static void sort_touched_columns_i32_rvv_f32(
+    int32_t *touched,
+    int32_t touched_count)
+{
+    if (touched_count <= 1)
+    {
+        return;
+    }
+
+    if (touched_count <= RVSP_SORT_INSERTION_LIMIT)
+    {
+        insertion_sort_i32_rvv_f32(touched, touched_count);
+        return;
+    }
+
+    qsort(
+        touched,
+        (size_t)touched_count,
+        sizeof(int32_t),
+        compare_i32_rvv_f32);
+}
+
 static void clear_f32_workspace(
     float *acc,
     uint8_t *mark,
     const int32_t *touched,
-    int32_t touched_count
-)
+    int32_t touched_count)
 {
-    for (int32_t i = 0; i < touched_count; i++) {
-        int32_t col = touched[i];
+    for (int32_t i = 0; i < touched_count; i++)
+    {
+        const int32_t col = touched[i];
         acc[col] = 0.0f;
         mark[col] = 0;
+    }
+}
+
+static void clear_f32_marks_only(
+    uint8_t *mark,
+    const int32_t *touched,
+    int32_t touched_count)
+{
+    for (int32_t i = 0; i < touched_count; i++)
+    {
+        mark[touched[i]] = 0;
     }
 }
 
@@ -41,21 +109,57 @@ static rvsp_status_t mark_f32_row_columns(
     float *acc,
     uint8_t *mark,
     int32_t *touched,
-    int32_t *touched_count
-)
+    int32_t *touched_count)
 {
-    for (int32_t p = 0; p < b_nnz; p++) {
-        int32_t col = b_col_idx[p];
+    for (int32_t p = 0; p < b_nnz; p++)
+    {
+        const int32_t col = b_col_idx[p];
 
-        if (col < 0 || col >= b_cols) {
+        if (RVSP_UNLIKELY(col < 0 || col >= b_cols))
+        {
             return RVSP_ERROR_INVALID_ARGUMENT;
         }
 
-        if (mark[col] == 0) {
+        if (mark[col] == 0)
+        {
             mark[col] = 1;
             touched[*touched_count] = col;
             (*touched_count)++;
             acc[col] = 0.0f;
+        }
+    }
+
+    return RVSP_SUCCESS;
+}
+
+/*
+ * Pure symbolic marking helper.
+ *
+ * This helper intentionally does not touch acc[col].
+ * It is used only in the symbolic upper-bound pass.
+ */
+static rvsp_status_t mark_f32_row_columns_symbolic(
+    int32_t b_nnz,
+    const int32_t *b_col_idx,
+    int32_t b_cols,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *touched_count)
+{
+    for (int32_t p = 0; p < b_nnz; p++)
+    {
+        const int32_t col = b_col_idx[p];
+
+        if (RVSP_UNLIKELY(col < 0 || col >= b_cols))
+        {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (mark[col] == 0)
+        {
+            mark[col] = 1;
+            touched[*touched_count] = col;
+            (*touched_count)++;
         }
     }
 
@@ -71,17 +175,74 @@ static rvsp_status_t accumulate_f32_row_scalar_marked(
     float *acc,
     uint8_t *mark,
     int32_t *touched,
-    int32_t *touched_count
-)
+    int32_t *touched_count)
 {
-    for (int32_t p = 0; p < b_nnz; p++) {
-        int32_t col = b_col_idx[p];
+    int32_t p = 0;
 
-        if (col < 0 || col >= b_cols) {
+    for (; p + 3 < b_nnz; p += 4)
+    {
+        const int32_t c0 = b_col_idx[p + 0];
+        const int32_t c1 = b_col_idx[p + 1];
+        const int32_t c2 = b_col_idx[p + 2];
+        const int32_t c3 = b_col_idx[p + 3];
+
+        if (RVSP_UNLIKELY(c0 < 0 || c0 >= b_cols ||
+                          c1 < 0 || c1 >= b_cols ||
+                          c2 < 0 || c2 >= b_cols ||
+                          c3 < 0 || c3 >= b_cols))
+        {
             return RVSP_ERROR_INVALID_ARGUMENT;
         }
 
-        if (mark[col] == 0) {
+        if (mark[c0] == 0)
+        {
+            mark[c0] = 1;
+            touched[*touched_count] = c0;
+            (*touched_count)++;
+            acc[c0] = 0.0f;
+        }
+
+        if (mark[c1] == 0)
+        {
+            mark[c1] = 1;
+            touched[*touched_count] = c1;
+            (*touched_count)++;
+            acc[c1] = 0.0f;
+        }
+
+        if (mark[c2] == 0)
+        {
+            mark[c2] = 1;
+            touched[*touched_count] = c2;
+            (*touched_count)++;
+            acc[c2] = 0.0f;
+        }
+
+        if (mark[c3] == 0)
+        {
+            mark[c3] = 1;
+            touched[*touched_count] = c3;
+            (*touched_count)++;
+            acc[c3] = 0.0f;
+        }
+
+        acc[c0] += a_val * b_values[p + 0];
+        acc[c1] += a_val * b_values[p + 1];
+        acc[c2] += a_val * b_values[p + 2];
+        acc[c3] += a_val * b_values[p + 3];
+    }
+
+    for (; p < b_nnz; p++)
+    {
+        const int32_t col = b_col_idx[p];
+
+        if (RVSP_UNLIKELY(col < 0 || col >= b_cols))
+        {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        if (mark[col] == 0)
+        {
             mark[col] = 1;
             touched[*touched_count] = col;
             (*touched_count)++;
@@ -99,66 +260,96 @@ static rvsp_status_t build_b_duplicate_flags_f32(
     int32_t b_cols,
     const int32_t *b_row_ptr,
     const int32_t *b_col_idx,
-    uint8_t *b_has_duplicates
-)
+    uint8_t *b_has_duplicates)
 {
     uint8_t *seen = NULL;
     int32_t *seen_touched = NULL;
+    rvsp_status_t status = RVSP_SUCCESS;
 
-    if (b_cols > 0) {
+    if (b_cols > 0)
+    {
         seen = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
         seen_touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
 
-        if (seen == NULL || seen_touched == NULL) {
-            free(seen);
-            free(seen_touched);
-            return RVSP_ERROR_ALLOCATION_FAILED;
+        if (seen == NULL || seen_touched == NULL)
+        {
+            status = RVSP_ERROR_ALLOCATION_FAILED;
+            goto cleanup;
         }
     }
 
-    for (int32_t row = 0; row < b_rows; row++) {
-        int32_t start = b_row_ptr[row];
-        int32_t end = b_row_ptr[row + 1];
+    for (int32_t row = 0; row < b_rows; row++)
+    {
+        const int32_t start = b_row_ptr[row];
+        const int32_t end = b_row_ptr[row + 1];
 
-        if (start < 0 || end < start) {
-            free(seen);
-            free(seen_touched);
-            return RVSP_ERROR_INVALID_ARGUMENT;
+        if (RVSP_UNLIKELY(start < 0 || end < start))
+        {
+            status = RVSP_ERROR_INVALID_ARGUMENT;
+            goto cleanup;
+        }
+
+        if (end - start <= 1)
+        {
+            continue;
         }
 
         int32_t seen_count = 0;
 
-        for (int32_t p = start; p < end; p++) {
-            int32_t col = b_col_idx[p];
+        for (int32_t p = start; p < end; p++)
+        {
+            const int32_t col = b_col_idx[p];
 
-            if (col < 0 || col >= b_cols) {
-                for (int32_t i = 0; i < seen_count; i++) {
-                    seen[seen_touched[i]] = 0;
-                }
-
-                free(seen);
-                free(seen_touched);
-                return RVSP_ERROR_INVALID_ARGUMENT;
+            if (RVSP_UNLIKELY(col < 0 || col >= b_cols))
+            {
+                status = RVSP_ERROR_INVALID_ARGUMENT;
+                break;
             }
 
-            if (seen[col] != 0) {
+            if (seen[col] != 0)
+            {
                 b_has_duplicates[row] = 1;
-            } else {
+            }
+            else
+            {
                 seen[col] = 1;
                 seen_touched[seen_count] = col;
                 seen_count++;
             }
         }
 
-        for (int32_t i = 0; i < seen_count; i++) {
+        for (int32_t i = 0; i < seen_count; i++)
+        {
             seen[seen_touched[i]] = 0;
+        }
+
+        if (status != RVSP_SUCCESS)
+        {
+            goto cleanup;
         }
     }
 
+cleanup:
     free(seen);
     free(seen_touched);
+    return status;
+}
 
-    return RVSP_SUCCESS;
+static inline int should_use_rvv_f32(
+    int32_t b_nnz,
+    uint8_t has_duplicates)
+{
+    if (has_duplicates)
+    {
+        return 0;
+    }
+
+    if (b_nnz < RVSP_RVV_F32_MIN_B_NNZ)
+    {
+        return 0;
+    }
+
+    return 1;
 }
 
 static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
@@ -171,10 +362,10 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
     uint8_t *mark,
     int32_t *touched,
     int32_t *touched_count,
-    uint8_t has_duplicates
-)
+    uint8_t has_duplicates)
 {
-    if (has_duplicates) {
+    if (!should_use_rvv_f32(b_nnz, has_duplicates))
+    {
         return accumulate_f32_row_scalar_marked(
             a_val,
             b_nnz,
@@ -184,8 +375,7 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
             acc,
             mark,
             touched,
-            touched_count
-        );
+            touched_count);
     }
 
     rvsp_status_t status = mark_f32_row_columns(
@@ -195,10 +385,10 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
         acc,
         mark,
         touched,
-        touched_count
-    );
+        touched_count);
 
-    if (status != RVSP_SUCCESS) {
+    if (status != RVSP_SUCCESS)
+    {
         return status;
     }
 
@@ -207,11 +397,97 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
         b_nnz,
         b_col_idx,
         b_values,
-        acc
-    );
+        acc);
 }
 
-rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
+static rvsp_status_t symbolic_count_pass_f32(
+    int32_t a_rows,
+    int32_t a_cols,
+    int32_t b_cols,
+    const int32_t *a_row_ptr,
+    const int32_t *a_col_idx,
+    const int32_t *b_row_ptr,
+    const int32_t *b_col_idx,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *c_row_ptr,
+    int64_t *total_nnz_out)
+{
+    int64_t total_nnz = 0;
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        const int32_t a_start = a_row_ptr[row];
+        const int32_t a_end = a_row_ptr[row + 1];
+
+        if (RVSP_UNLIKELY(a_start < 0 || a_end < a_start))
+        {
+            return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        int32_t touched_count = 0;
+
+        for (int32_t ap = a_start; ap < a_end; ap++)
+        {
+            const int32_t a_col = a_col_idx[ap];
+
+            if (RVSP_UNLIKELY(a_col < 0 || a_col >= a_cols))
+            {
+                clear_f32_marks_only(mark, touched, touched_count);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            const int32_t b_start = b_row_ptr[a_col];
+            const int32_t b_end = b_row_ptr[a_col + 1];
+
+            if (RVSP_UNLIKELY(b_start < 0 || b_end < b_start))
+            {
+                clear_f32_marks_only(mark, touched, touched_count);
+                return RVSP_ERROR_INVALID_ARGUMENT;
+            }
+
+            rvsp_status_t status = mark_f32_row_columns_symbolic(
+                b_end - b_start,
+                &b_col_idx[b_start],
+                b_cols,
+                mark,
+                touched,
+                &touched_count);
+
+            if (status != RVSP_SUCCESS)
+            {
+                clear_f32_marks_only(mark, touched, touched_count);
+                return status;
+            }
+        }
+
+        c_row_ptr[row] = touched_count;
+        total_nnz += touched_count;
+
+        clear_f32_marks_only(mark, touched, touched_count);
+
+        if (RVSP_UNLIKELY(total_nnz > INT32_MAX))
+        {
+            return RVSP_ERROR_ALLOCATION_FAILED;
+        }
+    }
+
+    int32_t running = 0;
+
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        const int32_t count = c_row_ptr[row];
+        c_row_ptr[row] = running;
+        running += count;
+    }
+
+    c_row_ptr[a_rows] = running;
+    *total_nnz_out = total_nnz;
+
+    return RVSP_SUCCESS;
+}
+
+static rvsp_status_t numeric_emit_pass_f32(
     int32_t a_rows,
     int32_t a_cols,
     int32_t b_cols,
@@ -221,195 +497,30 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
     const int32_t *b_row_ptr,
     const int32_t *b_col_idx,
     const float *b_values,
-    int32_t **c_row_ptr_out,
-    int32_t **c_col_idx_out,
-    float **c_values_out,
-    int32_t *c_nnz_out
-)
+    const uint8_t *b_has_duplicates,
+    float *acc,
+    uint8_t *mark,
+    int32_t *touched,
+    int32_t *c_row_ptr,
+    int32_t *c_col_idx,
+    float *c_values)
 {
-    if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
-        a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
-        b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
-        c_row_ptr_out == NULL || c_col_idx_out == NULL ||
-        c_values_out == NULL || c_nnz_out == NULL) {
-        return RVSP_ERROR_INVALID_ARGUMENT;
-    }
+    (void)a_cols;
 
-    *c_row_ptr_out = NULL;
-    *c_col_idx_out = NULL;
-    *c_values_out = NULL;
-    *c_nnz_out = 0;
-
-    int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
-    float *acc = NULL;
-    int32_t *touched = NULL;
-    uint8_t *mark = NULL;
-    uint8_t *b_has_duplicates = NULL;
-
-    if (c_row_ptr == NULL) {
-        return RVSP_ERROR_ALLOCATION_FAILED;
-    }
-
-    if (b_cols > 0) {
-        acc = (float *)malloc((size_t)b_cols * sizeof(float));
-        touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
-        mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
-
-        if (acc == NULL || touched == NULL || mark == NULL) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            return RVSP_ERROR_ALLOCATION_FAILED;
-        }
-    }
-
-    if (a_cols > 0) {
-        b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
-
-        if (b_has_duplicates == NULL) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            return RVSP_ERROR_ALLOCATION_FAILED;
-        }
-
-        rvsp_status_t status = build_b_duplicate_flags_f32(
-            a_cols,
-            b_cols,
-            b_row_ptr,
-            b_col_idx,
-            b_has_duplicates
-        );
-
-        if (status != RVSP_SUCCESS) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            free(b_has_duplicates);
-            return status;
-        }
-    }
-
-    // Symbolic pass.
-    int64_t total_nnz = 0;
-
-    for (int32_t row = 0; row < a_rows; row++) {
-        int32_t a_start = a_row_ptr[row];
-        int32_t a_end = a_row_ptr[row + 1];
-
-        if (a_start < 0 || a_end < a_start) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            free(b_has_duplicates);
-            return RVSP_ERROR_INVALID_ARGUMENT;
-        }
+    for (int32_t row = 0; row < a_rows; row++)
+    {
+        const int32_t a_start = a_row_ptr[row];
+        const int32_t a_end = a_row_ptr[row + 1];
 
         int32_t touched_count = 0;
+        int32_t dst = c_row_ptr[row];
+        const int32_t row_capacity_end = c_row_ptr[row + 1];
 
-        for (int32_t ap = a_start; ap < a_end; ap++) {
-            int32_t a_col = a_col_idx[ap];
-
-            if (a_col < 0 || a_col >= a_cols) {
-                clear_f32_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
-                return RVSP_ERROR_INVALID_ARGUMENT;
-            }
-
-            int32_t b_start = b_row_ptr[a_col];
-            int32_t b_end = b_row_ptr[a_col + 1];
-
-            if (b_start < 0 || b_end < b_start) {
-                clear_f32_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
-                return RVSP_ERROR_INVALID_ARGUMENT;
-            }
-
-            rvsp_status_t status = mark_f32_row_columns(
-                b_end - b_start,
-                &b_col_idx[b_start],
-                b_cols,
-                acc,
-                mark,
-                touched,
-                &touched_count
-            );
-
-            if (status != RVSP_SUCCESS) {
-                clear_f32_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
-                return status;
-            }
-        }
-
-        c_row_ptr[row] = touched_count; // per-row count; prefix-summed below
-
-        total_nnz += touched_count;
-
-        clear_f32_workspace(acc, mark, touched, touched_count);
-
-        if (total_nnz > INT32_MAX) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            free(b_has_duplicates);
-            return RVSP_ERROR_ALLOCATION_FAILED;
-        }
-    }
-
-    // Exclusive prefix sum turns the per-row counts into row pointers.
-    int32_t running = 0;
-
-    for (int32_t row = 0; row < a_rows; row++) {
-        int32_t count = c_row_ptr[row];
-        c_row_ptr[row] = running;
-        running += count;
-    }
-
-    c_row_ptr[a_rows] = running;
-
-    size_t alloc_nnz = total_nnz > 0 ? (size_t)total_nnz : 1;
-    int32_t *c_col_idx = (int32_t *)malloc(alloc_nnz * sizeof(int32_t));
-    float *c_values = (float *)malloc(alloc_nnz * sizeof(float));
-
-    if (c_col_idx == NULL || c_values == NULL) {
-        free(c_row_ptr);
-        free(c_col_idx);
-        free(c_values);
-        free(acc);
-        free(touched);
-        free(mark);
-        free(b_has_duplicates);
-        return RVSP_ERROR_ALLOCATION_FAILED;
-    }
-
-    // Numeric pass.
-    for (int32_t row = 0; row < a_rows; row++) {
-        int32_t a_start = a_row_ptr[row];
-        int32_t a_end = a_row_ptr[row + 1];
-        int32_t touched_count = 0;
-
-        for (int32_t ap = a_start; ap < a_end; ap++) {
-            int32_t a_col = a_col_idx[ap];
-            int32_t b_start = b_row_ptr[a_col];
-            int32_t b_end = b_row_ptr[a_col + 1];
+        for (int32_t ap = a_start; ap < a_end; ap++)
+        {
+            const int32_t a_col = a_col_idx[ap];
+            const int32_t b_start = b_row_ptr[a_col];
+            const int32_t b_end = b_row_ptr[a_col + 1];
 
             rvsp_status_t status = accumulate_f32_row_rvv_or_scalar(
                 a_values[ap],
@@ -421,42 +532,170 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
                 mark,
                 touched,
                 &touched_count,
-                b_has_duplicates ? b_has_duplicates[a_col] : 0
-            );
+                b_has_duplicates ? b_has_duplicates[a_col] : 0);
 
-            if (status != RVSP_SUCCESS) {
+            if (status != RVSP_SUCCESS)
+            {
                 clear_f32_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(c_col_idx);
-                free(c_values);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
                 return status;
             }
         }
 
-        // Keep output rows in ascending column order (canonical CSR).
-        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_rvv_f32);
+        sort_touched_columns_i32_rvv_f32(touched, touched_count);
 
-        int32_t dst = c_row_ptr[row];
+        for (int32_t i = 0; i < touched_count; i++)
+        {
+            const int32_t col = touched[i];
 
-        for (int32_t i = 0; i < touched_count; i++) {
-            int32_t col = touched[i];
+            if (acc[col] != 0.0f)
+            {
+                if (RVSP_UNLIKELY(dst >= row_capacity_end))
+                {
+                    clear_f32_workspace(acc, mark, touched, touched_count);
+                    return RVSP_ERROR_INVALID_ARGUMENT;
+                }
 
-            // Entries that numerically cancel to zero are not stored.
-            if (acc[col] != 0.0f) {
                 c_col_idx[dst] = col;
                 c_values[dst] = acc[col];
                 dst++;
             }
-
             mark[col] = 0;
         }
 
-        // Symbolic counts are an upper bound since cancellation can shrink rows.
         c_row_ptr[row + 1] = dst;
+    }
+
+    return RVSP_SUCCESS;
+}
+
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols, const int32_t *a_row_ptr, const int32_t *a_col_idx, const float *a_values, const int32_t *b_row_ptr, const int32_t *b_col_idx, const float *b_values, int32_t **c_row_ptr_out, int32_t **c_col_idx_out, float **c_values_out, int32_t *c_nnz_out)
+{
+    rvsp_status_t status = RVSP_SUCCESS;
+
+    int32_t *c_row_ptr = NULL;
+    int32_t *c_col_idx = NULL;
+    float *c_values = NULL;
+
+    float *acc = NULL;
+    int32_t *touched = NULL;
+    uint8_t *mark = NULL;
+    uint8_t *b_has_duplicates = NULL;
+
+    int64_t total_nnz_upper = 0;
+
+    if (RVSP_UNLIKELY(a_rows < 0 || a_cols < 0 || b_cols < 0 ||
+                      a_row_ptr == NULL || a_col_idx == NULL ||
+                      a_values == NULL ||
+                      b_row_ptr == NULL || b_col_idx == NULL ||
+                      b_values == NULL ||
+                      c_row_ptr_out == NULL ||
+                      c_col_idx_out == NULL ||
+                      c_values_out == NULL ||
+                      c_nnz_out == NULL))
+    {
+        return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    *c_row_ptr_out = NULL;
+    *c_col_idx_out = NULL;
+    *c_values_out = NULL;
+    *c_nnz_out = 0;
+
+    c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
+    if (c_row_ptr == NULL)
+    {
+        status = RVSP_ERROR_ALLOCATION_FAILED;
+        goto fail;
+    }
+
+    if (b_cols > 0)
+    {
+        acc = (float *)malloc((size_t)b_cols * sizeof(float));
+        touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+        mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+
+        if (acc == NULL || touched == NULL || mark == NULL)
+        {
+            status = RVSP_ERROR_ALLOCATION_FAILED;
+            goto fail;
+        }
+    }
+
+    if (a_cols > 0)
+    {
+        b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
+        if (b_has_duplicates == NULL)
+        {
+            status = RVSP_ERROR_ALLOCATION_FAILED;
+            goto fail;
+        }
+
+        status = build_b_duplicate_flags_f32(
+            a_cols,
+            b_cols,
+            b_row_ptr,
+            b_col_idx,
+            b_has_duplicates);
+
+        if (status != RVSP_SUCCESS)
+        {
+            goto fail;
+        }
+    }
+
+    status = symbolic_count_pass_f32(
+        a_rows,
+        a_cols,
+        b_cols,
+        a_row_ptr,
+        a_col_idx,
+        b_row_ptr,
+        b_col_idx,
+        mark,
+        touched,
+        c_row_ptr,
+        &total_nnz_upper);
+
+    if (status != RVSP_SUCCESS)
+    {
+        goto fail;
+    }
+
+    {
+        const size_t alloc_nnz =
+            total_nnz_upper > 0 ? (size_t)total_nnz_upper : 1;
+
+        c_col_idx = (int32_t *)malloc(alloc_nnz * sizeof(int32_t));
+        c_values = (float *)malloc(alloc_nnz * sizeof(float));
+
+        if (c_col_idx == NULL || c_values == NULL)
+        {
+            status = RVSP_ERROR_ALLOCATION_FAILED;
+            goto fail;
+        }
+    }
+
+    status = numeric_emit_pass_f32(
+        a_rows,
+        a_cols,
+        b_cols,
+        a_row_ptr,
+        a_col_idx,
+        a_values,
+        b_row_ptr,
+        b_col_idx,
+        b_values,
+        b_has_duplicates,
+        acc,
+        mark,
+        touched,
+        c_row_ptr,
+        c_col_idx,
+        c_values);
+
+    if (status != RVSP_SUCCESS)
+    {
+        goto fail;
     }
 
     free(acc);
@@ -470,4 +709,15 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(
     *c_nnz_out = c_row_ptr[a_rows];
 
     return RVSP_SUCCESS;
+
+fail:
+    free(c_row_ptr);
+    free(c_col_idx);
+    free(c_values);
+    free(acc);
+    free(touched);
+    free(mark);
+    free(b_has_duplicates);
+
+    return status;
 }

--- a/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f32_indexed_marked.c
@@ -13,7 +13,7 @@
 #endif
 
 #ifndef RVSP_RVV_F32_MIN_B_NNZ
-#define RVSP_RVV_F32_MIN_B_NNZ 128
+#define RVSP_RVV_F32_MIN_B_NNZ 512
 #endif
 
 #ifndef RVSP_SORT_INSERTION_LIMIT
@@ -77,11 +77,10 @@ static void sort_touched_columns_i32_rvv_f32(
         compare_i32_rvv_f32);
 }
 
-static void clear_f32_workspace(
-    float *acc,
-    uint8_t *mark,
-    const int32_t *touched,
-    int32_t touched_count)
+static void clear_f32_workspace(float *acc,
+                                uint8_t *mark,
+                                const int32_t *touched,
+                                int32_t touched_count)
 {
     for (int32_t i = 0; i < touched_count; i++)
     {
@@ -132,19 +131,8 @@ static rvsp_status_t mark_f32_row_columns(
     return RVSP_SUCCESS;
 }
 
-/*
- * Pure symbolic marking helper.
- *
- * This helper intentionally does not touch acc[col].
- * It is used only in the symbolic upper-bound pass.
- */
-static rvsp_status_t mark_f32_row_columns_symbolic(
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    int32_t b_cols,
-    uint8_t *mark,
-    int32_t *touched,
-    int32_t *touched_count)
+static rvsp_status_t mark_f32_row_columns_symbolic(int32_t b_nnz, const int32_t *b_col_idx, int32_t b_cols,
+                                                   uint8_t *mark, int32_t *touched, int32_t *touched_count)
 {
     for (int32_t p = 0; p < b_nnz; p++)
     {
@@ -166,16 +154,15 @@ static rvsp_status_t mark_f32_row_columns_symbolic(
     return RVSP_SUCCESS;
 }
 
-static rvsp_status_t accumulate_f32_row_scalar_marked(
-    float a_val,
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    const float *b_values,
-    int32_t b_cols,
-    float *acc,
-    uint8_t *mark,
-    int32_t *touched,
-    int32_t *touched_count)
+static rvsp_status_t accumulate_f32_row_scalar_marked(float a_val,
+                                                      int32_t b_nnz,
+                                                      const int32_t *b_col_idx,
+                                                      const float *b_values,
+                                                      int32_t b_cols,
+                                                      float *acc,
+                                                      uint8_t *mark,
+                                                      int32_t *touched,
+                                                      int32_t *touched_count)
 {
     int32_t p = 0;
 
@@ -255,12 +242,9 @@ static rvsp_status_t accumulate_f32_row_scalar_marked(
     return RVSP_SUCCESS;
 }
 
-static rvsp_status_t build_b_duplicate_flags_f32(
-    int32_t b_rows,
-    int32_t b_cols,
-    const int32_t *b_row_ptr,
-    const int32_t *b_col_idx,
-    uint8_t *b_has_duplicates)
+static rvsp_status_t build_b_duplicate_flags_f32(int32_t b_rows, int32_t b_cols, const int32_t *b_row_ptr,
+                                                 const int32_t *b_col_idx,
+                                                 uint8_t *b_has_duplicates)
 {
     uint8_t *seen = NULL;
     int32_t *seen_touched = NULL;
@@ -366,52 +350,29 @@ static rvsp_status_t accumulate_f32_row_rvv_or_scalar(
 {
     if (!should_use_rvv_f32(b_nnz, has_duplicates))
     {
-        return accumulate_f32_row_scalar_marked(
-            a_val,
-            b_nnz,
-            b_col_idx,
-            b_values,
-            b_cols,
-            acc,
-            mark,
-            touched,
-            touched_count);
+        return accumulate_f32_row_scalar_marked(a_val, b_nnz, b_col_idx, b_values,
+                                                b_cols,
+                                                acc,
+                                                mark,
+                                                touched,
+                                                touched_count);
     }
 
-    rvsp_status_t status = mark_f32_row_columns(
-        b_nnz,
-        b_col_idx,
-        b_cols,
-        acc,
-        mark,
-        touched,
-        touched_count);
+    rvsp_status_t status = mark_f32_row_columns(b_nnz, b_col_idx, b_cols, acc, mark, touched, touched_count);
 
     if (status != RVSP_SUCCESS)
     {
         return status;
     }
 
-    return rvsp_accumulate_row_f32_rvv_indexed_fast(
-        a_val,
-        b_nnz,
-        b_col_idx,
-        b_values,
-        acc);
+    return rvsp_accumulate_row_f32_rvv_indexed_fast(a_val, b_nnz, b_col_idx, b_values, acc);
 }
 
-static rvsp_status_t symbolic_count_pass_f32(
-    int32_t a_rows,
-    int32_t a_cols,
-    int32_t b_cols,
-    const int32_t *a_row_ptr,
-    const int32_t *a_col_idx,
-    const int32_t *b_row_ptr,
-    const int32_t *b_col_idx,
-    uint8_t *mark,
-    int32_t *touched,
-    int32_t *c_row_ptr,
-    int64_t *total_nnz_out)
+static rvsp_status_t symbolic_count_pass_f32(int32_t a_rows, int32_t a_cols, int32_t b_cols, const int32_t *a_row_ptr,
+                                             const int32_t *a_col_idx,
+                                             const int32_t *b_row_ptr, const int32_t *b_col_idx,
+                                             uint8_t *mark, int32_t *touched, int32_t *c_row_ptr,
+                                             int64_t *total_nnz_out)
 {
     int64_t total_nnz = 0;
 
@@ -446,13 +407,8 @@ static rvsp_status_t symbolic_count_pass_f32(
                 return RVSP_ERROR_INVALID_ARGUMENT;
             }
 
-            rvsp_status_t status = mark_f32_row_columns_symbolic(
-                b_end - b_start,
-                &b_col_idx[b_start],
-                b_cols,
-                mark,
-                touched,
-                &touched_count);
+            rvsp_status_t status = mark_f32_row_columns_symbolic(b_end - b_start, &b_col_idx[b_start],
+                                                                 b_cols, mark, touched, &touched_count);
 
             if (status != RVSP_SUCCESS)
             {
@@ -487,23 +443,11 @@ static rvsp_status_t symbolic_count_pass_f32(
     return RVSP_SUCCESS;
 }
 
-static rvsp_status_t numeric_emit_pass_f32(
-    int32_t a_rows,
-    int32_t a_cols,
-    int32_t b_cols,
-    const int32_t *a_row_ptr,
-    const int32_t *a_col_idx,
-    const float *a_values,
-    const int32_t *b_row_ptr,
-    const int32_t *b_col_idx,
-    const float *b_values,
-    const uint8_t *b_has_duplicates,
-    float *acc,
-    uint8_t *mark,
-    int32_t *touched,
-    int32_t *c_row_ptr,
-    int32_t *c_col_idx,
-    float *c_values)
+static rvsp_status_t numeric_emit_pass_f32(int32_t a_rows, int32_t a_cols, int32_t b_cols, const int32_t *a_row_ptr,
+                                           const int32_t *a_col_idx, const float *a_values, const int32_t *b_row_ptr,
+                                           const int32_t *b_col_idx, const float *b_values, const uint8_t *b_has_duplicates,
+                                           float *acc, uint8_t *mark, int32_t *touched,
+                                           int32_t *c_row_ptr, int32_t *c_col_idx, float *c_values)
 {
     (void)a_cols;
 
@@ -568,7 +512,12 @@ static rvsp_status_t numeric_emit_pass_f32(
     return RVSP_SUCCESS;
 }
 
-rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols, const int32_t *a_row_ptr, const int32_t *a_col_idx, const float *a_values, const int32_t *b_row_ptr, const int32_t *b_col_idx, const float *b_values, int32_t **c_row_ptr_out, int32_t **c_col_idx_out, float **c_values_out, int32_t *c_nnz_out)
+rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t a_cols, int32_t b_cols,
+                                                         const int32_t *a_row_ptr, const int32_t *a_col_idx,
+                                                         const float *a_values, const int32_t *b_row_ptr,
+                                                         const int32_t *b_col_idx, const float *b_values,
+                                                         int32_t **c_row_ptr_out, int32_t **c_col_idx_out,
+                                                         float **c_values_out, int32_t *c_nnz_out)
 {
     rvsp_status_t status = RVSP_SUCCESS;
 
@@ -630,12 +579,7 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t
             goto fail;
         }
 
-        status = build_b_duplicate_flags_f32(
-            a_cols,
-            b_cols,
-            b_row_ptr,
-            b_col_idx,
-            b_has_duplicates);
+        status = build_b_duplicate_flags_f32(a_cols, b_cols, b_row_ptr, b_col_idx, b_has_duplicates);
 
         if (status != RVSP_SUCCESS)
         {
@@ -643,18 +587,9 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t
         }
     }
 
-    status = symbolic_count_pass_f32(
-        a_rows,
-        a_cols,
-        b_cols,
-        a_row_ptr,
-        a_col_idx,
-        b_row_ptr,
-        b_col_idx,
-        mark,
-        touched,
-        c_row_ptr,
-        &total_nnz_upper);
+    status = symbolic_count_pass_f32(a_rows, a_cols, b_cols, a_row_ptr, a_col_idx,
+                                     b_row_ptr, b_col_idx, mark, touched, c_row_ptr,
+                                     &total_nnz_upper);
 
     if (status != RVSP_SUCCESS)
     {
@@ -675,23 +610,9 @@ rvsp_status_t rvsp_spgemm_csr_rvv_f32_indexed_marked_raw(int32_t a_rows, int32_t
         }
     }
 
-    status = numeric_emit_pass_f32(
-        a_rows,
-        a_cols,
-        b_cols,
-        a_row_ptr,
-        a_col_idx,
-        a_values,
-        b_row_ptr,
-        b_col_idx,
-        b_values,
-        b_has_duplicates,
-        acc,
-        mark,
-        touched,
-        c_row_ptr,
-        c_col_idx,
-        c_values);
+    status = numeric_emit_pass_f32(a_rows, a_cols, b_cols, a_row_ptr, a_col_idx, a_values,
+                                   b_row_ptr, b_col_idx, b_values, b_has_duplicates, acc,
+                                   mark, touched, c_row_ptr, c_col_idx, c_values);
 
     if (status != RVSP_SUCCESS)
     {


### PR DESCRIPTION

This PR adds a configurable FP32 RVV accumulator policy framework for CSR SpGEMM.


It introduces three compile-time selectable policies:

- `RVSP_RVV_F32_ACCUM_POLICY=0`: baseline contiguous + indexed RVV
- `RVSP_RVV_F32_ACCUM_POLICY=1`: scan-ahead contiguous-only RVV
- `RVSP_RVV_F32_ACCUM_POLICY=2`: scan-ahead with indexed RVV only for large, irregular regions

The default remains Policy 0 to preserve stable behavior, while Policy 1 and Policy 2 enable matrix-aware tuning.

All tested policies preserved correctness against `scalar_f32`.