### PR TITLE
perf: port RVV accumulator policy framework to FP64

### DIFF
--- a/src/kernels/spgemm/accumulate_row_f64_rvv_indexed_fast.c
+++ b/src/kernels/spgemm/accumulate_row_f64_rvv_indexed_fast.c
@@ -1,5 +1,11 @@
-#include <stdint.h>
+/*
+ * Copyright (C) 2026 rv-sparse contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <stddef.h>
+#include <stdint.h>
 
 #include "csr_spgemm_kernels.h"
 
@@ -8,43 +14,372 @@
 #define RVSP_HAVE_RVV_INTRINSICS 1
 #endif
 
-rvsp_status_t rvsp_accumulate_row_f64_rvv_indexed_fast(
-    double a_val,
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    const double *b_values,
-    double *acc
-)
-{
-    if (b_nnz < 0 || b_col_idx == NULL || b_values == NULL || acc == NULL) {
-        return RVSP_ERROR_INVALID_ARGUMENT;
-    }
-
-#if defined(RVSP_HAVE_RVV_INTRINSICS)
-    int32_t p = 0;
-
-    while (p < b_nnz) {
-        size_t vl = __riscv_vsetvl_e64m4((size_t)(b_nnz - p));
-
-        vfloat64m4_t vb = __riscv_vle64_v_f64m4(&b_values[p], vl);
-        vfloat64m4_t vprod = __riscv_vfmul_vf_f64m4(vb, a_val, vl);
-
-        vint32m2_t vidx_i32 = __riscv_vle32_v_i32m2(&b_col_idx[p], vl);
-        vint32m2_t voff_i32 = __riscv_vsll_vx_i32m2(vidx_i32, 3, vl);
-        vuint32m2_t voff_u32 = __riscv_vreinterpret_v_i32m2_u32m2(voff_i32);
-
-        vfloat64m4_t vacc = __riscv_vluxei32_v_f64m4(acc, voff_u32, vl);
-        vacc = __riscv_vfadd_vv_f64m4(vacc, vprod, vl);
-        __riscv_vsuxei32_v_f64m4(acc, voff_u32, vacc, vl);
-
-        p += (int32_t)vl;
-    }
+#if defined(__GNUC__) || defined(__clang__)
+#define RVSP_LIKELY(x) __builtin_expect(!!(x), 1)
+#define RVSP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#define RVSP_RESTRICT __restrict__
 #else
-    for (int32_t p = 0; p < b_nnz; p++) {
-        int32_t col = b_col_idx[p];
-        acc[col] += a_val * b_values[p];
-    }
+#define RVSP_LIKELY(x) (x)
+#define RVSP_UNLIKELY(x) (x)
+#define RVSP_RESTRICT
 #endif
 
+#ifndef RVSP_RVV_F64_MIN_B_NNZ
+#define RVSP_RVV_F64_MIN_B_NNZ 256
+#endif
+
+#ifndef RVSP_RVV_F64_CONTIG_MIN
+#define RVSP_RVV_F64_CONTIG_MIN 4
+#endif
+
+#ifndef RVSP_RVV_F64_ACCUM_POLICY
+#define RVSP_RVV_F64_ACCUM_POLICY 0
+#endif
+
+#ifndef RVSP_RVV_F64_INDEXED_MIN
+#define RVSP_RVV_F64_INDEXED_MIN 1024
+#endif
+
+#ifndef RVSP_RVV_F64_SCAN_AHEAD_MAX
+#define RVSP_RVV_F64_SCAN_AHEAD_MAX 256
+#endif
+
+static inline int32_t rvsp_min_i32(int32_t a, int32_t b) {
+  return a < b ? a : b;
+}
+
+static inline void rvsp_accumulate_row_f64_scalar_unroll8(
+    double a_val, int32_t b_nnz, const int32_t* RVSP_RESTRICT b_col_idx,
+    const double* RVSP_RESTRICT b_values, double* RVSP_RESTRICT acc) {
+  int32_t p = 0;
+
+  for (; p + 7 < b_nnz; p += 8) {
+    const int32_t c0 = b_col_idx[p + 0];
+    const int32_t c1 = b_col_idx[p + 1];
+    const int32_t c2 = b_col_idx[p + 2];
+    const int32_t c3 = b_col_idx[p + 3];
+    const int32_t c4 = b_col_idx[p + 4];
+    const int32_t c5 = b_col_idx[p + 5];
+    const int32_t c6 = b_col_idx[p + 6];
+    const int32_t c7 = b_col_idx[p + 7];
+
+    acc[c0] += a_val * b_values[p + 0];
+    acc[c1] += a_val * b_values[p + 1];
+    acc[c2] += a_val * b_values[p + 2];
+    acc[c3] += a_val * b_values[p + 3];
+    acc[c4] += a_val * b_values[p + 4];
+    acc[c5] += a_val * b_values[p + 5];
+    acc[c6] += a_val * b_values[p + 6];
+    acc[c7] += a_val * b_values[p + 7];
+  }
+
+  for (; p + 3 < b_nnz; p += 4) {
+    const int32_t c0 = b_col_idx[p + 0];
+    const int32_t c1 = b_col_idx[p + 1];
+    const int32_t c2 = b_col_idx[p + 2];
+    const int32_t c3 = b_col_idx[p + 3];
+
+    acc[c0] += a_val * b_values[p + 0];
+    acc[c1] += a_val * b_values[p + 1];
+    acc[c2] += a_val * b_values[p + 2];
+    acc[c3] += a_val * b_values[p + 3];
+  }
+
+  for (; p < b_nnz; p++) {
+    const int32_t col = b_col_idx[p];
+    acc[col] += a_val * b_values[p];
+  }
+}
+
+static inline int32_t rvsp_consecutive_run_i32(const int32_t* RVSP_RESTRICT idx,
+                                               int32_t n) {
+  if (RVSP_UNLIKELY(idx == NULL || n <= 0)) {
+    return 0;
+  }
+
+  const int32_t base = idx[0];
+  int32_t run = 1;
+
+  while (run < n && idx[run] == base + run) {
+    run++;
+  }
+
+  return run;
+}
+
+static inline int32_t rvsp_find_next_contig_run_bounded_i32(
+    const int32_t* RVSP_RESTRICT idx, int32_t n, int32_t min_run,
+    int32_t scan_limit, int32_t* RVSP_RESTRICT run_out) {
+  if (RVSP_UNLIKELY(run_out == NULL)) {
+    return 0;
+  }
+
+  *run_out = 0;
+
+  if (RVSP_UNLIKELY(idx == NULL || n <= 0)) {
+    return 0;
+  }
+
+  if (min_run <= 1) {
+    *run_out = rvsp_consecutive_run_i32(idx, n);
+    return 0;
+  }
+
+  if (scan_limit <= 0) {
+    scan_limit = n;
+  }
+
+  const int32_t limit = rvsp_min_i32(n, scan_limit);
+
+  if (limit < min_run) {
+    return limit;
+  }
+
+  for (int32_t i = 0; i + min_run <= limit; i++) {
+    if (idx[i + 1] != idx[i] + 1) {
+      continue;
+    }
+
+    int32_t run = 2;
+
+    while (i + run < n && idx[i + run] == idx[i] + run) {
+      run++;
+    }
+
+    if (run >= min_run) {
+      *run_out = run;
+      return i;
+    }
+
+    i += run - 1;
+  }
+
+  return limit;
+}
+
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+
+static inline void rvsp_accumulate_row_f64_rvv_contig_chunk(
+    double a_val, int32_t n, int32_t base_col,
+    const double* RVSP_RESTRICT b_values, double* RVSP_RESTRICT acc) {
+  int32_t q = 0;
+
+  while (q < n) {
+    const size_t vl = __riscv_vsetvl_e64m4((size_t)(n - q));
+
+    const vfloat64m4_t vb = __riscv_vle64_v_f64m4(&b_values[q], vl);
+
+    vfloat64m4_t vacc = __riscv_vle64_v_f64m4(&acc[base_col + q], vl);
+
+    vacc = __riscv_vfmacc_vf_f64m4(vacc, a_val, vb, vl);
+
+    __riscv_vse64_v_f64m4(&acc[base_col + q], vacc, vl);
+
+    q += (int32_t)vl;
+  }
+}
+
+static inline void rvsp_accumulate_row_f64_rvv_indexed_chunk(
+    double a_val, int32_t n, const int32_t* RVSP_RESTRICT b_col_idx,
+    const double* RVSP_RESTRICT b_values, double* RVSP_RESTRICT acc) {
+  int32_t q = 0;
+
+  while (q < n) {
+    const size_t vl = __riscv_vsetvl_e64m2((size_t)(n - q));
+
+    const vfloat64m2_t vb = __riscv_vle64_v_f64m2(&b_values[q], vl);
+
+    const vint32m1_t vidx_i32 = __riscv_vle32_v_i32m1(&b_col_idx[q], vl);
+
+    const vuint32m1_t vidx_u32 = __riscv_vreinterpret_v_i32m1_u32m1(vidx_i32);
+
+    const vuint32m1_t voff_u32 = __riscv_vsll_vx_u32m1(vidx_u32, 3, vl);
+
+    vfloat64m2_t vacc = __riscv_vluxei32_v_f64m2(acc, voff_u32, vl);
+
+    vacc = __riscv_vfmacc_vf_f64m2(vacc, a_val, vb, vl);
+
+    __riscv_vsuxei32_v_f64m2(acc, voff_u32, vacc, vl);
+
+    q += (int32_t)vl;
+  }
+}
+
+#endif
+
+static inline void rvsp_accumulate_row_f64_policy0_baseline(
+    double a_val, int32_t b_nnz, const int32_t* RVSP_RESTRICT b_col_idx,
+    const double* RVSP_RESTRICT b_values, double* RVSP_RESTRICT acc) {
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+  int32_t p = 0;
+
+  while (p < b_nnz) {
+    const int32_t remaining = b_nnz - p;
+    const int32_t run = rvsp_consecutive_run_i32(&b_col_idx[p], remaining);
+
+    if (run >= RVSP_RVV_F64_CONTIG_MIN) {
+      rvsp_accumulate_row_f64_rvv_contig_chunk(a_val, run, b_col_idx[p],
+                                               &b_values[p], acc);
+
+      p += run;
+      continue;
+    }
+
+    {
+      const size_t vl = __riscv_vsetvl_e64m2((size_t)remaining);
+
+      const vfloat64m2_t vb = __riscv_vle64_v_f64m2(&b_values[p], vl);
+
+      const vint32m1_t vidx_i32 = __riscv_vle32_v_i32m1(&b_col_idx[p], vl);
+
+      const vuint32m1_t vidx_u32 = __riscv_vreinterpret_v_i32m1_u32m1(vidx_i32);
+
+      const vuint32m1_t voff_u32 = __riscv_vsll_vx_u32m1(vidx_u32, 3, vl);
+
+      vfloat64m2_t vacc = __riscv_vluxei32_v_f64m2(acc, voff_u32, vl);
+
+      vacc = __riscv_vfmacc_vf_f64m2(vacc, a_val, vb, vl);
+
+      __riscv_vsuxei32_v_f64m2(acc, voff_u32, vacc, vl);
+
+      p += (int32_t)vl;
+    }
+  }
+#else
+  rvsp_accumulate_row_f64_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values,
+                                         acc);
+#endif
+}
+
+static inline void rvsp_accumulate_row_f64_policy1_contig_only(
+    double a_val, int32_t b_nnz, const int32_t* RVSP_RESTRICT b_col_idx,
+    const double* RVSP_RESTRICT b_values, double* RVSP_RESTRICT acc) {
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+  int32_t p = 0;
+
+  while (p < b_nnz) {
+    const int32_t remaining = b_nnz - p;
+
+    int32_t run = 0;
+    const int32_t offset = rvsp_find_next_contig_run_bounded_i32(
+        &b_col_idx[p], remaining, RVSP_RVV_F64_CONTIG_MIN,
+        RVSP_RVV_F64_SCAN_AHEAD_MAX, &run);
+
+    if (offset > 0) {
+      rvsp_accumulate_row_f64_scalar_unroll8(a_val, offset, &b_col_idx[p],
+                                             &b_values[p], acc);
+
+      p += offset;
+      continue;
+    }
+
+    if (run >= RVSP_RVV_F64_CONTIG_MIN) {
+      rvsp_accumulate_row_f64_rvv_contig_chunk(a_val, run, b_col_idx[p],
+                                               &b_values[p], acc);
+
+      p += run;
+      continue;
+    }
+
+    rvsp_accumulate_row_f64_scalar_unroll8(a_val, remaining, &b_col_idx[p],
+                                           &b_values[p], acc);
+
+    p += remaining;
+  }
+#else
+  rvsp_accumulate_row_f64_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values,
+                                         acc);
+#endif
+}
+
+static inline void rvsp_accumulate_row_f64_policy2_indexed_threshold(
+    double a_val, int32_t b_nnz, const int32_t* RVSP_RESTRICT b_col_idx,
+    const double* RVSP_RESTRICT b_values, double* RVSP_RESTRICT acc) {
+#if defined(RVSP_HAVE_RVV_INTRINSICS)
+  int32_t p = 0;
+
+  while (p < b_nnz) {
+    const int32_t remaining = b_nnz - p;
+    const int32_t scan_limit =
+        rvsp_min_i32(remaining, RVSP_RVV_F64_SCAN_AHEAD_MAX);
+
+    int32_t run = 0;
+    const int32_t offset = rvsp_find_next_contig_run_bounded_i32(
+        &b_col_idx[p], remaining, RVSP_RVV_F64_CONTIG_MIN, scan_limit, &run);
+
+    if (offset == scan_limit && run == 0 &&
+        remaining >= RVSP_RVV_F64_INDEXED_MIN) {
+      rvsp_accumulate_row_f64_rvv_indexed_chunk(a_val, remaining, &b_col_idx[p],
+                                                &b_values[p], acc);
+
+      p += remaining;
+      continue;
+    }
+
+    if (offset > 0) {
+      rvsp_accumulate_row_f64_scalar_unroll8(a_val, offset, &b_col_idx[p],
+                                             &b_values[p], acc);
+
+      p += offset;
+      continue;
+    }
+
+    if (run >= RVSP_RVV_F64_CONTIG_MIN) {
+      rvsp_accumulate_row_f64_rvv_contig_chunk(a_val, run, b_col_idx[p],
+                                               &b_values[p], acc);
+
+      p += run;
+      continue;
+    }
+
+    rvsp_accumulate_row_f64_scalar_unroll8(a_val, remaining, &b_col_idx[p],
+                                           &b_values[p], acc);
+
+    p += remaining;
+  }
+#else
+  rvsp_accumulate_row_f64_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values,
+                                         acc);
+#endif
+}
+
+rvsp_status_t rvsp_accumulate_row_f64_rvv_indexed_fast(double a_val,
+                                                       int32_t b_nnz,
+                                                       const int32_t* b_col_idx,
+                                                       const double* b_values,
+                                                       double* acc) {
+  if (RVSP_UNLIKELY(b_nnz < 0 || b_col_idx == NULL || b_values == NULL ||
+                    acc == NULL)) {
+    return RVSP_ERROR_INVALID_ARGUMENT;
+  }
+
+  if (b_nnz == 0) {
     return RVSP_SUCCESS;
+  }
+
+  if (a_val == 0.0) {
+    return RVSP_SUCCESS;
+  }
+
+  if (b_nnz < RVSP_RVV_F64_MIN_B_NNZ) {
+    rvsp_accumulate_row_f64_scalar_unroll8(a_val, b_nnz, b_col_idx, b_values,
+                                           acc);
+
+    return RVSP_SUCCESS;
+  }
+
+#if RVSP_RVV_F64_ACCUM_POLICY == 0
+  rvsp_accumulate_row_f64_policy0_baseline(a_val, b_nnz, b_col_idx, b_values,
+                                           acc);
+#elif RVSP_RVV_F64_ACCUM_POLICY == 1
+  rvsp_accumulate_row_f64_policy1_contig_only(a_val, b_nnz, b_col_idx, b_values,
+                                              acc);
+#elif RVSP_RVV_F64_ACCUM_POLICY == 2
+  rvsp_accumulate_row_f64_policy2_indexed_threshold(a_val, b_nnz, b_col_idx,
+                                                    b_values, acc);
+#else
+#error "Unsupported RVSP_RVV_F64_ACCUM_POLICY. Use 0, 1, or 2."
+#endif
+
+  return RVSP_SUCCESS;
 }

--- a/src/kernels/spgemm/csr_rvv_f64_indexed_marked.c
+++ b/src/kernels/spgemm/csr_rvv_f64_indexed_marked.c
@@ -1,473 +1,553 @@
+/*
+ * Copyright (C) 2026 rv-sparse contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ */
+
+#include <limits.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <limits.h>
 
 #include "csr_spgemm_kernels.h"
 
-static int compare_i32_rvv_f64(const void *a, const void *b)
-{
-    int32_t ia = *(const int32_t *)a;
-    int32_t ib = *(const int32_t *)b;
+#if defined(__GNUC__) || defined(__clang__)
+#define RVSP_LIKELY(x) __builtin_expect(!!(x), 1)
+#define RVSP_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define RVSP_LIKELY(x) (x)
+#define RVSP_UNLIKELY(x) (x)
+#endif
 
-    if (ia < ib) {
-        return -1;
-    }
+#ifndef RVSP_RVV_F64_MIN_B_NNZ
+#define RVSP_RVV_F64_MIN_B_NNZ 256
+#endif
 
-    if (ia > ib) {
-        return 1;
-    }
+#ifndef RVSP_SORT_INSERTION_LIMIT
+#define RVSP_SORT_INSERTION_LIMIT 32
+#endif
 
-    return 0;
+static int compare_i32_rvv_f64(const void* a, const void* b) {
+  const int32_t ia = *(const int32_t*)a;
+  const int32_t ib = *(const int32_t*)b;
+
+  if (ia < ib) {
+    return -1;
+  }
+
+  if (ia > ib) {
+    return 1;
+  }
+
+  return 0;
 }
 
-static void clear_f64_workspace(
-    double *acc,
-    uint8_t *mark,
-    const int32_t *touched,
-    int32_t touched_count
-)
-{
-    for (int32_t i = 0; i < touched_count; i++) {
-        int32_t col = touched[i];
-        acc[col] = 0.0;
-        mark[col] = 0;
+static void insertion_sort_i32_rvv_f64(int32_t* x, int32_t n) {
+  for (int32_t i = 1; i < n; i++) {
+    const int32_t key = x[i];
+    int32_t j = i - 1;
+
+    while (j >= 0 && x[j] > key) {
+      x[j + 1] = x[j];
+      j--;
     }
+
+    x[j + 1] = key;
+  }
 }
 
-static rvsp_status_t mark_f64_row_columns(
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    int32_t b_cols,
-    double *acc,
-    uint8_t *mark,
-    int32_t *touched,
-    int32_t *touched_count
-)
-{
-    for (int32_t p = 0; p < b_nnz; p++) {
-        int32_t col = b_col_idx[p];
+static void sort_touched_columns_i32_rvv_f64(int32_t* touched,
+                                             int32_t touched_count) {
+  if (touched_count <= 1) {
+    return;
+  }
 
-        if (col < 0 || col >= b_cols) {
-            return RVSP_ERROR_INVALID_ARGUMENT;
-        }
+  if (touched_count <= RVSP_SORT_INSERTION_LIMIT) {
+    insertion_sort_i32_rvv_f64(touched, touched_count);
+    return;
+  }
 
-        if (mark[col] == 0) {
-            mark[col] = 1;
-            touched[*touched_count] = col;
-            (*touched_count)++;
-            acc[col] = 0.0;
-        }
+  qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_rvv_f64);
+}
+
+static void clear_f64_workspace(double* acc, uint8_t* mark,
+                                const int32_t* touched, int32_t touched_count) {
+  for (int32_t i = 0; i < touched_count; i++) {
+    const int32_t col = touched[i];
+    acc[col] = 0.0;
+    mark[col] = 0;
+  }
+}
+
+static void clear_f64_marks_only(uint8_t* mark, const int32_t* touched,
+                                 int32_t touched_count) {
+  for (int32_t i = 0; i < touched_count; i++) {
+    mark[touched[i]] = 0;
+  }
+}
+
+static rvsp_status_t mark_f64_row_columns(int32_t b_nnz,
+                                          const int32_t* b_col_idx,
+                                          int32_t b_cols, double* acc,
+                                          uint8_t* mark, int32_t* touched,
+                                          int32_t* touched_count) {
+  for (int32_t p = 0; p < b_nnz; p++) {
+    const int32_t col = b_col_idx[p];
+
+    if (RVSP_UNLIKELY(col < 0 || col >= b_cols)) {
+      return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
-    return RVSP_SUCCESS;
+    if (mark[col] == 0) {
+      mark[col] = 1;
+      touched[*touched_count] = col;
+      (*touched_count)++;
+      acc[col] = 0.0;
+    }
+  }
+
+  return RVSP_SUCCESS;
+}
+
+static rvsp_status_t mark_f64_row_columns_symbolic(
+    int32_t b_nnz, const int32_t* b_col_idx, int32_t b_cols, uint8_t* mark,
+    int32_t* touched, int32_t* touched_count) {
+  for (int32_t p = 0; p < b_nnz; p++) {
+    const int32_t col = b_col_idx[p];
+
+    if (RVSP_UNLIKELY(col < 0 || col >= b_cols)) {
+      return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (mark[col] == 0) {
+      mark[col] = 1;
+      touched[*touched_count] = col;
+      (*touched_count)++;
+    }
+  }
+
+  return RVSP_SUCCESS;
 }
 
 static rvsp_status_t accumulate_f64_row_scalar_marked(
-    double a_val,
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    const double *b_values,
-    int32_t b_cols,
-    double *acc,
-    uint8_t *mark,
-    int32_t *touched,
-    int32_t *touched_count
-)
-{
-    for (int32_t p = 0; p < b_nnz; p++) {
-        int32_t col = b_col_idx[p];
+    double a_val, int32_t b_nnz, const int32_t* b_col_idx,
+    const double* b_values, int32_t b_cols, double* acc, uint8_t* mark,
+    int32_t* touched, int32_t* touched_count) {
+  int32_t p = 0;
 
-        if (col < 0 || col >= b_cols) {
-            return RVSP_ERROR_INVALID_ARGUMENT;
-        }
+  for (; p + 3 < b_nnz; p += 4) {
+    const int32_t c0 = b_col_idx[p + 0];
+    const int32_t c1 = b_col_idx[p + 1];
+    const int32_t c2 = b_col_idx[p + 2];
+    const int32_t c3 = b_col_idx[p + 3];
 
-        if (mark[col] == 0) {
-            mark[col] = 1;
-            touched[*touched_count] = col;
-            (*touched_count)++;
-            acc[col] = 0.0;
-        }
-
-        acc[col] += a_val * b_values[p];
+    if (RVSP_UNLIKELY(c0 < 0 || c0 >= b_cols || c1 < 0 || c1 >= b_cols ||
+                      c2 < 0 || c2 >= b_cols || c3 < 0 || c3 >= b_cols)) {
+      return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
-    return RVSP_SUCCESS;
+    if (mark[c0] == 0) {
+      mark[c0] = 1;
+      touched[*touched_count] = c0;
+      (*touched_count)++;
+      acc[c0] = 0.0;
+    }
+
+    if (mark[c1] == 0) {
+      mark[c1] = 1;
+      touched[*touched_count] = c1;
+      (*touched_count)++;
+      acc[c1] = 0.0;
+    }
+
+    if (mark[c2] == 0) {
+      mark[c2] = 1;
+      touched[*touched_count] = c2;
+      (*touched_count)++;
+      acc[c2] = 0.0;
+    }
+
+    if (mark[c3] == 0) {
+      mark[c3] = 1;
+      touched[*touched_count] = c3;
+      (*touched_count)++;
+      acc[c3] = 0.0;
+    }
+
+    acc[c0] += a_val * b_values[p + 0];
+    acc[c1] += a_val * b_values[p + 1];
+    acc[c2] += a_val * b_values[p + 2];
+    acc[c3] += a_val * b_values[p + 3];
+  }
+
+  for (; p < b_nnz; p++) {
+    const int32_t col = b_col_idx[p];
+
+    if (RVSP_UNLIKELY(col < 0 || col >= b_cols)) {
+      return RVSP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (mark[col] == 0) {
+      mark[col] = 1;
+      touched[*touched_count] = col;
+      (*touched_count)++;
+      acc[col] = 0.0;
+    }
+
+    acc[col] += a_val * b_values[p];
+  }
+
+  return RVSP_SUCCESS;
 }
 
-static rvsp_status_t build_b_duplicate_flags_f64(
-    int32_t b_rows,
-    int32_t b_cols,
-    const int32_t *b_row_ptr,
-    const int32_t *b_col_idx,
-    uint8_t *b_has_duplicates
-)
-{
-    uint8_t *seen = NULL;
-    int32_t *seen_touched = NULL;
+static rvsp_status_t build_b_duplicate_flags_f64(int32_t b_rows, int32_t b_cols,
+                                                 const int32_t* b_row_ptr,
+                                                 const int32_t* b_col_idx,
+                                                 uint8_t* b_has_duplicates) {
+  uint8_t* seen = NULL;
+  int32_t* seen_touched = NULL;
+  rvsp_status_t status = RVSP_SUCCESS;
 
-    if (b_cols > 0) {
-        seen = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
-        seen_touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
+  if (b_cols > 0) {
+    seen = (uint8_t*)calloc((size_t)b_cols, sizeof(uint8_t));
+    seen_touched = (int32_t*)malloc((size_t)b_cols * sizeof(int32_t));
 
-        if (seen == NULL || seen_touched == NULL) {
-            free(seen);
-            free(seen_touched);
-            return RVSP_ERROR_ALLOCATION_FAILED;
-        }
+    if (seen == NULL || seen_touched == NULL) {
+      status = RVSP_ERROR_ALLOCATION_FAILED;
+      goto cleanup;
+    }
+  }
+
+  for (int32_t row = 0; row < b_rows; row++) {
+    const int32_t start = b_row_ptr[row];
+    const int32_t end = b_row_ptr[row + 1];
+
+    if (RVSP_UNLIKELY(start < 0 || end < start)) {
+      status = RVSP_ERROR_INVALID_ARGUMENT;
+      goto cleanup;
     }
 
-    for (int32_t row = 0; row < b_rows; row++) {
-        int32_t start = b_row_ptr[row];
-        int32_t end = b_row_ptr[row + 1];
-
-        if (start < 0 || end < start) {
-            free(seen);
-            free(seen_touched);
-            return RVSP_ERROR_INVALID_ARGUMENT;
-        }
-
-        int32_t seen_count = 0;
-
-        for (int32_t p = start; p < end; p++) {
-            int32_t col = b_col_idx[p];
-
-            if (col < 0 || col >= b_cols) {
-                for (int32_t i = 0; i < seen_count; i++) {
-                    seen[seen_touched[i]] = 0;
-                }
-
-                free(seen);
-                free(seen_touched);
-                return RVSP_ERROR_INVALID_ARGUMENT;
-            }
-
-            if (seen[col] != 0) {
-                b_has_duplicates[row] = 1;
-            } else {
-                seen[col] = 1;
-                seen_touched[seen_count] = col;
-                seen_count++;
-            }
-        }
-
-        for (int32_t i = 0; i < seen_count; i++) {
-            seen[seen_touched[i]] = 0;
-        }
+    if (end - start <= 1) {
+      continue;
     }
 
-    free(seen);
-    free(seen_touched);
+    int32_t seen_count = 0;
 
-    return RVSP_SUCCESS;
+    for (int32_t p = start; p < end; p++) {
+      const int32_t col = b_col_idx[p];
+
+      if (RVSP_UNLIKELY(col < 0 || col >= b_cols)) {
+        status = RVSP_ERROR_INVALID_ARGUMENT;
+        break;
+      }
+
+      if (seen[col] != 0) {
+        b_has_duplicates[row] = 1;
+      } else {
+        seen[col] = 1;
+        seen_touched[seen_count] = col;
+        seen_count++;
+      }
+    }
+
+    for (int32_t i = 0; i < seen_count; i++) {
+      seen[seen_touched[i]] = 0;
+    }
+
+    if (status != RVSP_SUCCESS) {
+      goto cleanup;
+    }
+  }
+
+cleanup:
+  free(seen);
+  free(seen_touched);
+  return status;
+}
+
+static inline int should_use_rvv_f64(int32_t b_nnz, uint8_t has_duplicates) {
+  if (has_duplicates) {
+    return 0;
+  }
+
+  if (b_nnz < RVSP_RVV_F64_MIN_B_NNZ) {
+    return 0;
+  }
+
+  return 1;
 }
 
 static rvsp_status_t accumulate_f64_row_rvv_or_scalar(
-    double a_val,
-    int32_t b_nnz,
-    const int32_t *b_col_idx,
-    const double *b_values,
-    int32_t b_cols,
-    double *acc,
-    uint8_t *mark,
-    int32_t *touched,
-    int32_t *touched_count,
-    uint8_t has_duplicates
-)
-{
-    if (has_duplicates) {
-        return accumulate_f64_row_scalar_marked(
-            a_val,
-            b_nnz,
-            b_col_idx,
-            b_values,
-            b_cols,
-            acc,
-            mark,
-            touched,
-            touched_count
-        );
+    double a_val, int32_t b_nnz, const int32_t* b_col_idx,
+    const double* b_values, int32_t b_cols, double* acc, uint8_t* mark,
+    int32_t* touched, int32_t* touched_count, uint8_t has_duplicates) {
+  if (RVSP_UNLIKELY(b_nnz < 0 || b_cols < 0 || touched_count == NULL)) {
+    return RVSP_ERROR_INVALID_ARGUMENT;
+  }
+
+  if (b_nnz == 0 || a_val == 0.0) {
+    return RVSP_SUCCESS;
+  }
+
+  if (RVSP_UNLIKELY(b_col_idx == NULL || b_values == NULL || acc == NULL ||
+                    mark == NULL || touched == NULL)) {
+    return RVSP_ERROR_INVALID_ARGUMENT;
+  }
+
+  if (!should_use_rvv_f64(b_nnz, has_duplicates)) {
+    return accumulate_f64_row_scalar_marked(a_val, b_nnz, b_col_idx, b_values,
+                                            b_cols, acc, mark, touched,
+                                            touched_count);
+  }
+
+  rvsp_status_t status = mark_f64_row_columns(b_nnz, b_col_idx, b_cols, acc,
+                                              mark, touched, touched_count);
+
+  if (status != RVSP_SUCCESS) {
+    return status;
+  }
+
+  return rvsp_accumulate_row_f64_rvv_indexed_fast(a_val, b_nnz, b_col_idx,
+                                                  b_values, acc);
+}
+
+static rvsp_status_t symbolic_count_pass_f64(
+    int32_t a_rows, int32_t a_cols, int32_t b_cols, const int32_t* a_row_ptr,
+    const int32_t* a_col_idx, const int32_t* b_row_ptr,
+    const int32_t* b_col_idx, uint8_t* mark, int32_t* touched,
+    int32_t* c_row_ptr, int64_t* total_nnz_out) {
+  int64_t total_nnz = 0;
+
+  for (int32_t row = 0; row < a_rows; row++) {
+    const int32_t a_start = a_row_ptr[row];
+    const int32_t a_end = a_row_ptr[row + 1];
+
+    if (RVSP_UNLIKELY(a_start < 0 || a_end < a_start)) {
+      return RVSP_ERROR_INVALID_ARGUMENT;
     }
 
-    rvsp_status_t status = mark_f64_row_columns(
-        b_nnz,
-        b_col_idx,
-        b_cols,
-        acc,
-        mark,
-        touched,
-        touched_count
-    );
+    int32_t touched_count = 0;
 
-    if (status != RVSP_SUCCESS) {
+    for (int32_t ap = a_start; ap < a_end; ap++) {
+      const int32_t a_col = a_col_idx[ap];
+
+      if (RVSP_UNLIKELY(a_col < 0 || a_col >= a_cols)) {
+        clear_f64_marks_only(mark, touched, touched_count);
+        return RVSP_ERROR_INVALID_ARGUMENT;
+      }
+
+      const int32_t b_start = b_row_ptr[a_col];
+      const int32_t b_end = b_row_ptr[a_col + 1];
+
+      if (RVSP_UNLIKELY(b_start < 0 || b_end < b_start)) {
+        clear_f64_marks_only(mark, touched, touched_count);
+        return RVSP_ERROR_INVALID_ARGUMENT;
+      }
+
+      rvsp_status_t status =
+          mark_f64_row_columns_symbolic(b_end - b_start, &b_col_idx[b_start],
+                                        b_cols, mark, touched, &touched_count);
+
+      if (status != RVSP_SUCCESS) {
+        clear_f64_marks_only(mark, touched, touched_count);
         return status;
+      }
     }
 
-    return rvsp_accumulate_row_f64_rvv_indexed_fast(
-        a_val,
-        b_nnz,
-        b_col_idx,
-        b_values,
-        acc
-    );
+    c_row_ptr[row] = touched_count;
+    total_nnz += touched_count;
+
+    clear_f64_marks_only(mark, touched, touched_count);
+
+    if (RVSP_UNLIKELY(total_nnz > INT32_MAX)) {
+      return RVSP_ERROR_ALLOCATION_FAILED;
+    }
+  }
+
+  int32_t running = 0;
+
+  for (int32_t row = 0; row < a_rows; row++) {
+    const int32_t count = c_row_ptr[row];
+    c_row_ptr[row] = running;
+    running += count;
+  }
+
+  c_row_ptr[a_rows] = running;
+  *total_nnz_out = total_nnz;
+
+  return RVSP_SUCCESS;
+}
+
+static rvsp_status_t numeric_emit_pass_f64(
+    int32_t a_rows, int32_t a_cols, int32_t b_cols, const int32_t* a_row_ptr,
+    const int32_t* a_col_idx, const double* a_values, const int32_t* b_row_ptr,
+    const int32_t* b_col_idx, const double* b_values,
+    const uint8_t* b_has_duplicates, double* acc, uint8_t* mark,
+    int32_t* touched, int32_t* c_row_ptr, int32_t* c_col_idx,
+    double* c_values) {
+  (void)a_cols;
+
+  for (int32_t row = 0; row < a_rows; row++) {
+    const int32_t a_start = a_row_ptr[row];
+    const int32_t a_end = a_row_ptr[row + 1];
+
+    int32_t touched_count = 0;
+    int32_t dst = c_row_ptr[row];
+    const int32_t row_capacity_end = c_row_ptr[row + 1];
+
+    for (int32_t ap = a_start; ap < a_end; ap++) {
+      const int32_t a_col = a_col_idx[ap];
+      const int32_t b_start = b_row_ptr[a_col];
+      const int32_t b_end = b_row_ptr[a_col + 1];
+
+      rvsp_status_t status = accumulate_f64_row_rvv_or_scalar(
+          a_values[ap], b_end - b_start, &b_col_idx[b_start],
+          &b_values[b_start], b_cols, acc, mark, touched, &touched_count,
+          b_has_duplicates ? b_has_duplicates[a_col] : 0);
+
+      if (status != RVSP_SUCCESS) {
+        clear_f64_workspace(acc, mark, touched, touched_count);
+        return status;
+      }
+    }
+
+    sort_touched_columns_i32_rvv_f64(touched, touched_count);
+
+    for (int32_t i = 0; i < touched_count; i++) {
+      const int32_t col = touched[i];
+
+      if (acc[col] != 0.0) {
+        if (RVSP_UNLIKELY(dst >= row_capacity_end)) {
+          clear_f64_workspace(acc, mark, touched, touched_count);
+          return RVSP_ERROR_INVALID_ARGUMENT;
+        }
+
+        c_col_idx[dst] = col;
+        c_values[dst] = acc[col];
+        dst++;
+      }
+
+      mark[col] = 0;
+    }
+
+    c_row_ptr[row + 1] = dst;
+  }
+
+  return RVSP_SUCCESS;
 }
 
 rvsp_status_t rvsp_spgemm_csr_rvv_f64_indexed_marked_raw(
-    int32_t a_rows,
-    int32_t a_cols,
-    int32_t b_cols,
-    const int32_t *a_row_ptr,
-    const int32_t *a_col_idx,
-    const double *a_values,
-    const int32_t *b_row_ptr,
-    const int32_t *b_col_idx,
-    const double *b_values,
-    int32_t **c_row_ptr_out,
-    int32_t **c_col_idx_out,
-    double **c_values_out,
-    int32_t *c_nnz_out
-)
-{
-    if (a_rows < 0 || a_cols < 0 || b_cols < 0 ||
-        a_row_ptr == NULL || a_col_idx == NULL || a_values == NULL ||
-        b_row_ptr == NULL || b_col_idx == NULL || b_values == NULL ||
-        c_row_ptr_out == NULL || c_col_idx_out == NULL ||
-        c_values_out == NULL || c_nnz_out == NULL) {
-        return RVSP_ERROR_INVALID_ARGUMENT;
+    int32_t a_rows, int32_t a_cols, int32_t b_cols, const int32_t* a_row_ptr,
+    const int32_t* a_col_idx, const double* a_values, const int32_t* b_row_ptr,
+    const int32_t* b_col_idx, const double* b_values, int32_t** c_row_ptr_out,
+    int32_t** c_col_idx_out, double** c_values_out, int32_t* c_nnz_out) {
+  rvsp_status_t status = RVSP_SUCCESS;
+
+  int32_t* c_row_ptr = NULL;
+  int32_t* c_col_idx = NULL;
+  double* c_values = NULL;
+
+  double* acc = NULL;
+  int32_t* touched = NULL;
+  uint8_t* mark = NULL;
+  uint8_t* b_has_duplicates = NULL;
+
+  int64_t total_nnz_upper = 0;
+
+  if (RVSP_UNLIKELY(
+          a_rows < 0 || a_cols < 0 || b_cols < 0 || a_row_ptr == NULL ||
+          a_col_idx == NULL || a_values == NULL || b_row_ptr == NULL ||
+          b_col_idx == NULL || b_values == NULL || c_row_ptr_out == NULL ||
+          c_col_idx_out == NULL || c_values_out == NULL || c_nnz_out == NULL)) {
+    return RVSP_ERROR_INVALID_ARGUMENT;
+  }
+
+  *c_row_ptr_out = NULL;
+  *c_col_idx_out = NULL;
+  *c_values_out = NULL;
+  *c_nnz_out = 0;
+
+  c_row_ptr = (int32_t*)calloc((size_t)a_rows + 1, sizeof(int32_t));
+  if (c_row_ptr == NULL) {
+    status = RVSP_ERROR_ALLOCATION_FAILED;
+    goto fail;
+  }
+
+  if (b_cols > 0) {
+    acc = (double*)malloc((size_t)b_cols * sizeof(double));
+    touched = (int32_t*)malloc((size_t)b_cols * sizeof(int32_t));
+    mark = (uint8_t*)calloc((size_t)b_cols, sizeof(uint8_t));
+
+    if (acc == NULL || touched == NULL || mark == NULL) {
+      status = RVSP_ERROR_ALLOCATION_FAILED;
+      goto fail;
+    }
+  }
+
+  if (a_cols > 0) {
+    b_has_duplicates = (uint8_t*)calloc((size_t)a_cols, sizeof(uint8_t));
+    if (b_has_duplicates == NULL) {
+      status = RVSP_ERROR_ALLOCATION_FAILED;
+      goto fail;
     }
 
-    *c_row_ptr_out = NULL;
-    *c_col_idx_out = NULL;
-    *c_values_out = NULL;
-    *c_nnz_out = 0;
+    status = build_b_duplicate_flags_f64(a_cols, b_cols, b_row_ptr, b_col_idx,
+                                         b_has_duplicates);
 
-    int32_t *c_row_ptr = (int32_t *)calloc((size_t)a_rows + 1, sizeof(int32_t));
-    double *acc = NULL;
-    int32_t *touched = NULL;
-    uint8_t *mark = NULL;
-    uint8_t *b_has_duplicates = NULL;
-
-    if (c_row_ptr == NULL) {
-        return RVSP_ERROR_ALLOCATION_FAILED;
+    if (status != RVSP_SUCCESS) {
+      goto fail;
     }
+  }
 
-    if (b_cols > 0) {
-        acc = (double *)malloc((size_t)b_cols * sizeof(double));
-        touched = (int32_t *)malloc((size_t)b_cols * sizeof(int32_t));
-        mark = (uint8_t *)calloc((size_t)b_cols, sizeof(uint8_t));
+  status = symbolic_count_pass_f64(a_rows, a_cols, b_cols, a_row_ptr, a_col_idx,
+                                   b_row_ptr, b_col_idx, mark, touched,
+                                   c_row_ptr, &total_nnz_upper);
 
-        if (acc == NULL || touched == NULL || mark == NULL) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            return RVSP_ERROR_ALLOCATION_FAILED;
-        }
-    }
+  if (status != RVSP_SUCCESS) {
+    goto fail;
+  }
 
-    if (a_cols > 0) {
-        b_has_duplicates = (uint8_t *)calloc((size_t)a_cols, sizeof(uint8_t));
+  {
+    const size_t alloc_nnz = total_nnz_upper > 0 ? (size_t)total_nnz_upper : 1;
 
-        if (b_has_duplicates == NULL) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            return RVSP_ERROR_ALLOCATION_FAILED;
-        }
-
-        rvsp_status_t status = build_b_duplicate_flags_f64(
-            a_cols,
-            b_cols,
-            b_row_ptr,
-            b_col_idx,
-            b_has_duplicates
-        );
-
-        if (status != RVSP_SUCCESS) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            free(b_has_duplicates);
-            return status;
-        }
-    }
-
-    // Symbolic pass.
-    int64_t total_nnz = 0;
-
-    for (int32_t row = 0; row < a_rows; row++) {
-        int32_t a_start = a_row_ptr[row];
-        int32_t a_end = a_row_ptr[row + 1];
-
-        if (a_start < 0 || a_end < a_start) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            free(b_has_duplicates);
-            return RVSP_ERROR_INVALID_ARGUMENT;
-        }
-
-        int32_t touched_count = 0;
-
-        for (int32_t ap = a_start; ap < a_end; ap++) {
-            int32_t a_col = a_col_idx[ap];
-
-            if (a_col < 0 || a_col >= a_cols) {
-                clear_f64_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
-                return RVSP_ERROR_INVALID_ARGUMENT;
-            }
-
-            int32_t b_start = b_row_ptr[a_col];
-            int32_t b_end = b_row_ptr[a_col + 1];
-
-            if (b_start < 0 || b_end < b_start) {
-                clear_f64_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
-                return RVSP_ERROR_INVALID_ARGUMENT;
-            }
-
-            rvsp_status_t status = mark_f64_row_columns(
-                b_end - b_start,
-                &b_col_idx[b_start],
-                b_cols,
-                acc,
-                mark,
-                touched,
-                &touched_count
-            );
-
-            if (status != RVSP_SUCCESS) {
-                clear_f64_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
-                return status;
-            }
-        }
-
-        c_row_ptr[row] = touched_count; // per-row count; prefix-summed below
-
-        total_nnz += touched_count;
-
-        clear_f64_workspace(acc, mark, touched, touched_count);
-
-        if (total_nnz > INT32_MAX) {
-            free(c_row_ptr);
-            free(acc);
-            free(touched);
-            free(mark);
-            free(b_has_duplicates);
-            return RVSP_ERROR_ALLOCATION_FAILED;
-        }
-    }
-
-    // Exclusive prefix sum turns the per-row counts into row pointers.
-    int32_t running = 0;
-
-    for (int32_t row = 0; row < a_rows; row++) {
-        int32_t count = c_row_ptr[row];
-        c_row_ptr[row] = running;
-        running += count;
-    }
-
-    c_row_ptr[a_rows] = running;
-
-    size_t alloc_nnz = total_nnz > 0 ? (size_t)total_nnz : 1;
-    int32_t *c_col_idx = (int32_t *)malloc(alloc_nnz * sizeof(int32_t));
-    double *c_values = (double *)malloc(alloc_nnz * sizeof(double));
+    c_col_idx = (int32_t*)malloc(alloc_nnz * sizeof(int32_t));
+    c_values = (double*)malloc(alloc_nnz * sizeof(double));
 
     if (c_col_idx == NULL || c_values == NULL) {
-        free(c_row_ptr);
-        free(c_col_idx);
-        free(c_values);
-        free(acc);
-        free(touched);
-        free(mark);
-        free(b_has_duplicates);
-        return RVSP_ERROR_ALLOCATION_FAILED;
+      status = RVSP_ERROR_ALLOCATION_FAILED;
+      goto fail;
     }
+  }
 
-    // Numeric pass.
-    for (int32_t row = 0; row < a_rows; row++) {
-        int32_t a_start = a_row_ptr[row];
-        int32_t a_end = a_row_ptr[row + 1];
-        int32_t touched_count = 0;
+  status = numeric_emit_pass_f64(a_rows, a_cols, b_cols, a_row_ptr, a_col_idx,
+                                 a_values, b_row_ptr, b_col_idx, b_values,
+                                 b_has_duplicates, acc, mark, touched,
+                                 c_row_ptr, c_col_idx, c_values);
 
-        for (int32_t ap = a_start; ap < a_end; ap++) {
-            int32_t a_col = a_col_idx[ap];
-            int32_t b_start = b_row_ptr[a_col];
-            int32_t b_end = b_row_ptr[a_col + 1];
+  if (status != RVSP_SUCCESS) {
+    goto fail;
+  }
 
-            rvsp_status_t status = accumulate_f64_row_rvv_or_scalar(
-                a_values[ap],
-                b_end - b_start,
-                &b_col_idx[b_start],
-                &b_values[b_start],
-                b_cols,
-                acc,
-                mark,
-                touched,
-                &touched_count,
-                b_has_duplicates ? b_has_duplicates[a_col] : 0
-            );
+  free(acc);
+  free(touched);
+  free(mark);
+  free(b_has_duplicates);
 
-            if (status != RVSP_SUCCESS) {
-                clear_f64_workspace(acc, mark, touched, touched_count);
-                free(c_row_ptr);
-                free(c_col_idx);
-                free(c_values);
-                free(acc);
-                free(touched);
-                free(mark);
-                free(b_has_duplicates);
-                return status;
-            }
-        }
+  *c_row_ptr_out = c_row_ptr;
+  *c_col_idx_out = c_col_idx;
+  *c_values_out = c_values;
+  *c_nnz_out = c_row_ptr[a_rows];
 
-        // Keep output rows in ascending column order (canonical CSR).
-        qsort(touched, (size_t)touched_count, sizeof(int32_t), compare_i32_rvv_f64);
+  return RVSP_SUCCESS;
 
-        int32_t dst = c_row_ptr[row];
+fail:
+  free(c_row_ptr);
+  free(c_col_idx);
+  free(c_values);
+  free(acc);
+  free(touched);
+  free(mark);
+  free(b_has_duplicates);
 
-        for (int32_t i = 0; i < touched_count; i++) {
-            int32_t col = touched[i];
-
-            // Entries that numerically cancel to zero are not stored.
-            if (acc[col] != 0.0) {
-                c_col_idx[dst] = col;
-                c_values[dst] = acc[col];
-                dst++;
-            }
-
-            mark[col] = 0;
-        }
-
-        // Symbolic counts are an upper bound since cancellation can shrink rows.
-        c_row_ptr[row + 1] = dst;
-    }
-
-    free(acc);
-    free(touched);
-    free(mark);
-    free(b_has_duplicates);
-
-    *c_row_ptr_out = c_row_ptr;
-    *c_col_idx_out = c_col_idx;
-    *c_values_out = c_values;
-    *c_nnz_out = c_row_ptr[a_rows];
-
-    return RVSP_SUCCESS;
+  return status;
 }


### PR DESCRIPTION
This PR ports the optimized RVV FP32 accumulator structure to the FP64 CSR SpGEMM path.

It updates:

- `accumulate_row_f64_rvv_indexed_fast.c`
- `csr_rvv_f64_indexed_marked.c`

Tested on five real matrices with GCC 16.1.0 and `rv64gcv`.
Policy 0 results for `rvv_f64` vs `scalar_f64`:

- mean speedup: 1.176x
- median speedup: 1.127x
- wins: 5/5

Per-matrix speedups:

- m133-b3: 1.390x
- mario002: 1.262x
- p2p-Gnutella31: 1.127x
- scircuit: 1.074x
- ca-CondMat: 1.029x

## Scope

This PR only modifies the FP64 SpGEMM RVV path. It does not include I8 changes, tiling, API changes, or directory reorganization.

<img width="2176" height="1074" alt="image" src="https://github.com/user-attachments/assets/0714b8ba-dc18-4623-ae05-abdade199ab8" />

<img width="2176" height="1074" alt="image" src="https://github.com/user-attachments/assets/c0c2b845-b783-4072-a392-a868047055a5" />
